### PR TITLE
Utilize tag on fastAPI paths to only create tools when opted-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0]
+
+### Changed
+
+- Introduced `include_in_mcp` tag - unless this is included in tags for FastAPI paths,
+  we will exclude the paths from being converted into MCP tools. This is introduce
+  opt-in conversion of paths-> tools.
+
 ## [0.1.3]
 
 ### Fixed
+
 - Dependency resolution issue with `mcp` package and `pydantic-settings`
 
 ## [0.1.2]
 
 ### Changed
+
 - Complete refactor: transformed from a code generator to a direct integration library
 - Replaced the CLI-based approach with a direct API for adding MCP servers to FastAPI applications
 - Integrated MCP servers now mount directly to FastAPI apps at runtime instead of generating separate code
@@ -20,18 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed code generation entirely in favor of runtime integration
 
 ### Added
+
 - Main `add_mcp_server` function for simple MCP server integration
 - Support for adding custom MCP tools alongside API-derived tools
 - Improved test suite
 - Manage with uv
 
 ### Removed
+
 - CLI interface and all associated commands (generate, run, install, etc.)
 - Code generation functionality
 
 ## [0.1.1] - 2024-07-03
 
 ### Fixed
+
 - Added support for PEP 604 union type syntax (e.g., `str | None`) in FastAPI endpoints
 - Improved type handling in model field generation for newer Python versions (3.10+)
 - Fixed compatibility issues with modern type annotations in path parameters, query parameters, and Pydantic models
@@ -39,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2024-03-08
 
 ### Added
+
 - Initial release of FastAPI-MCP
 - Core functionality for converting FastAPI applications to MCP servers
 - CLI tool for generating, running, and installing MCP servers
@@ -48,4 +62,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude integration for easy installation and use
 - API integration that automatically makes HTTP requests to FastAPI endpoints
 - Examples directory with sample FastAPI application
-- Basic test suite 
+- Basic test suite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0]
+## [0.2.0]
 
 ### Changed
 
-- Introduced `include_in_mcp` tag - unless this is included in tags for FastAPI paths,
-  we will exclude the paths from being converted into MCP tools. This is introduce
+- Introduced `include_in_mcp` tag- unless this is included in tags for FastAPI paths,
+  we will exclude the paths from being converted into MCP tools. This is to introduce
   opt-in conversion of paths-> tools.
+  - This feature is only enabled when the user sets the 'create_tools_by_default'
+    variable to false when calling `add_mcp_server`
 
 ## [0.1.3]
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,24 @@ add_mcp_server(
 
 That's it! Your auto-generated MCP server is now available at `https://app.base.url/mcp`.
 
+By default, all paths listed in the FastAPI app provided _will not have MCP tools created for them._
+There are a fair number of paths that folks might not want tools for- as such, tool creation is `opt-in`.
+
+If you wish to include a path in tool creation, you can do so using a `include_in_mcp` tag
+
+Ex)
+
+```
+    @app.post("/items/", response_model=Item, tags=["items", "include_in_mcp"])
+    async def create_item(item: Item):
+        """
+        Create a new item.
+
+        Returns the created item.
+        """
+        return item
+```
+
 ## Advanced Usage
 
 FastAPI-MCP provides several ways to customize and control how your MCP server is created and configured. Here are some advanced usage patterns:

--- a/README.md
+++ b/README.md
@@ -49,10 +49,23 @@ add_mcp_server(
 
 That's it! Your auto-generated MCP server is now available at `https://app.base.url/mcp`.
 
-By default, all paths listed in the FastAPI app provided _will not have MCP tools created for them._
-There are a fair number of paths that folks might not want tools for- as such, tool creation is `opt-in`.
+By default, all registered FastAPI paths will have MCP tools created for them
 
-If you wish to include a path in tool creation, you can do so using a `include_in_mcp` tag
+If you wish to turn on the ability to not have tools created by default, pass
+the `create_tools_by_default = false` flag into your `add_mcp_server` call.
+
+Ex )
+
+```
+add_mcp_server(
+    app,
+    mount_path="/mcp",
+    name="My API MCP",
+    create_tools_by_default = false
+)
+```
+
+Then, for each path you wish to create a tool for, include the following in the path's tags: `include_in_mcp`
 
 Ex)
 
@@ -66,6 +79,8 @@ Ex)
         """
         return item
 ```
+
+If `create_tools_by_default` is not set, any paths _without_ the `include_in_mcp` tag will not have a corresponding MCP tool created.
 
 ## Advanced Usage
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Ex)
         return item
 ```
 
-If `create_tools_by_default` is not set, any paths _without_ the `include_in_mcp` tag will not have a corresponding MCP tool created.
+If `create_tools_by_default` is set to 'false', any paths _without_ the `include_in_mcp` tag will not have a corresponding MCP tool created.
 
 ## Advanced Usage
 

--- a/examples/simple_integration.py
+++ b/examples/simple_integration.py
@@ -31,7 +31,7 @@ items_db: dict[int, Item] = {}
 
 
 # Define some endpoints
-@app.get("/items/", response_model=List[Item], tags=["items"])
+@app.get("/items/", response_model=List[Item], tags=["items", "include_in_mcp"])
 async def list_items(skip: int = 0, limit: int = 10):
     """
     List all items in the database.
@@ -41,7 +41,7 @@ async def list_items(skip: int = 0, limit: int = 10):
     return list(items_db.values())[skip : skip + limit]
 
 
-@app.get("/items/{item_id}", response_model=Item, tags=["items"])
+@app.get("/items/{item_id}", response_model=Item, tags=["items", "include_in_mcp"])
 async def read_item(item_id: int):
     """
     Get a specific item by its ID.
@@ -53,7 +53,7 @@ async def read_item(item_id: int):
     return items_db[item_id]
 
 
-@app.post("/items/", response_model=Item, tags=["items"])
+@app.post("/items/", response_model=Item, tags=["items", "include_in_mcp"])
 async def create_item(item: Item):
     """
     Create a new item in the database.
@@ -64,7 +64,7 @@ async def create_item(item: Item):
     return item
 
 
-@app.put("/items/{item_id}", response_model=Item, tags=["items"])
+@app.put("/items/{item_id}", response_model=Item, tags=["items", "include_in_mcp"])
 async def update_item(item_id: int, item: Item):
     """
     Update an existing item.
@@ -79,7 +79,7 @@ async def update_item(item_id: int, item: Item):
     return item
 
 
-@app.delete("/items/{item_id}", tags=["items"])
+@app.delete("/items/{item_id}", tags=["items", "include_in_mcp"])
 async def delete_item(item_id: int):
     """
     Delete an item from the database.
@@ -93,7 +93,7 @@ async def delete_item(item_id: int):
     return {"message": "Item deleted successfully"}
 
 
-@app.get("/items/search/", response_model=List[Item], tags=["search"])
+@app.get("/items/search/", response_model=List[Item], tags=["search", "include_in_mcp"])
 async def search_items(
     q: Optional[str] = Query(None, description="Search query string"),
     min_price: Optional[float] = Query(None, description="Minimum price"),

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -6,7 +6,7 @@ This module provides functionality for creating MCP tools from FastAPI endpoints
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 import httpx
 from fastapi import FastAPI
@@ -149,11 +149,15 @@ def create_mcp_tools_from_openapi(
             if method not in ["get", "post", "put", "delete", "patch"]:
                 continue
 
+            # Skip registering tools we have tagged with 'exclude_from_mcp'
+            if 'exclude_from_mcp' in operation.get("tags", []):
+                continue
+
             # Get operation metadata
             operation_id = operation.get("operationId")
             if not operation_id:
                 continue
-
+            
             # Create MCP tool for this operation
             create_http_tool(
                 mcp_server=mcp_server,

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -149,8 +149,8 @@ def create_mcp_tools_from_openapi(
             if method not in ["get", "post", "put", "delete", "patch"]:
                 continue
 
-            # Skip registering tools we have tagged with 'exclude_from_mcp'
-            if 'exclude_from_mcp' in operation.get("tags", []):
+            # Skip registering tools unless they are explicitly allowed
+            if 'include_in_mcp' not in operation.get("tags", []) and  "handle_mcp_connection_mcp_get" not in operation.get("operationId", ""):
                 continue
 
             # Get operation metadata

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -6,7 +6,7 @@ This module provides functionality for creating MCP tools from FastAPI endpoints
 
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import httpx
 from fastapi import FastAPI

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -105,6 +105,7 @@ def create_mcp_tools_from_openapi(
     base_url: Optional[str] = None,
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    create_tools_by_default: bool = True,
 ) -> None:
     """
     Create MCP tools from a FastAPI app's OpenAPI schema.
@@ -149,10 +150,11 @@ def create_mcp_tools_from_openapi(
             if method not in ["get", "post", "put", "delete", "patch"]:
                 continue
 
+            # If we do not create tools by default,
             # Skip registering tools unless they are explicitly allowed
-            if 'include_in_mcp' not in operation.get("tags", []) and  "handle_mcp_connection_mcp_get" not in operation.get("operationId", ""):
-                continue
-
+            if not create_tools_by_default:
+                if 'include_in_mcp' not in operation.get("tags", []) and "handle_mcp_connection_mcp_get" not in operation.get("operationId", ""):
+                    continue
             # Get operation metadata
             operation_id = operation.get("operationId")
             if not operation_id:

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -14,11 +14,14 @@ from starlette.requests import Request
 from .http_tools import create_mcp_tools_from_openapi
 
 
+create_tools_by_default = True
+
 def create_mcp_server(
     app: FastAPI,
     name: Optional[str] = None,
     description: Optional[str] = None,
     capabilities: Optional[Dict[str, Any]] = None,
+    create_tools_by_default: Optional[bool] = True
 ) -> FastMCP:
     """
     Create an MCP server from a FastAPI app.
@@ -28,6 +31,9 @@ def create_mcp_server(
         name: Name for the MCP server (defaults to app.title)
         description: Description for the MCP server (defaults to app.description)
         capabilities: Optional capabilities for the MCP server
+        create_tools_by_default: Optional bool value  use to indicate if we should
+            consider 'include_in_mcp' when creating tools from FastAPI paths
+            
 
     Returns:
         The created FastMCP instance
@@ -56,6 +62,7 @@ def mount_mcp_server(
     base_url: Optional[str] = None,
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    create_tools_by_default: bool = True
 ) -> None:
     """
     Mount an MCP server to a FastAPI app.
@@ -99,6 +106,7 @@ def mount_mcp_server(
             base_url,
             describe_all_responses=describe_all_responses,
             describe_full_response_schema=describe_full_response_schema,
+            create_tools_by_default=create_tools_by_default
         )
 
 
@@ -112,6 +120,7 @@ def add_mcp_server(
     base_url: Optional[str] = None,
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    create_tools_by_default: bool = True
 ) -> FastMCP:
     """
     Add an MCP server to a FastAPI app.
@@ -142,6 +151,7 @@ def add_mcp_server(
         base_url,
         describe_all_responses=describe_all_responses,
         describe_full_response_schema=describe_full_response_schema,
+        create_tools_by_default=create_tools_by_default
     )
 
     return mcp_server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi-mcp"
-version = "2.0.0"
+version = "0.2.0"
 description = "Automatic MCP server generator for FastAPI applications - converts FastAPI endpoints to MCP tools for LLM integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi-mcp"
-version = "0.1.3"
+version = "2.0.0"
 description = "Automatic MCP server generator for FastAPI applications - converts FastAPI endpoints to MCP tools for LLM integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = pyproject_data["project"]["dependencies"]
 
 setup(
     name="fastapi-mcp",
-    version="0.1.3",
+    version="0.2.0",
     description="Automatic MCP server generator for FastAPI applications - converts FastAPI endpoints to MCP tools for LLM integration",
     author="Tadata Inc.",
     author_email="itay@tadata.com",

--- a/tests/test_http_tools.py
+++ b/tests/test_http_tools.py
@@ -32,7 +32,7 @@ def complex_app():
         version="0.1.0",
     )
 
-    @app.get("/items/", response_model=List[Item], tags=["items", "include_in_mcp"])
+    @app.get("/items/", response_model=List[Item], tags=["items"])
     async def list_items(
         skip: int = Query(0, description="Number of items to skip"),
         limit: int = Query(10, description="Max number of items to return"),
@@ -41,7 +41,7 @@ def complex_app():
         """List all items with pagination and sorting options."""
         return []
 
-    @app.get("/items/{item_id}", response_model=Item, tags=["items", "include_in_mcp"])
+    @app.get("/items/{item_id}", response_model=Item, tags=["items"])
     async def read_item(
         item_id: int = Path(..., description="The ID of the item to retrieve"),
         include_details: bool = Query(False, description="Include additional details"),
@@ -49,12 +49,12 @@ def complex_app():
         """Get a specific item by its ID with optional details."""
         return {"id": item_id, "name": "Test Item", "price": 10.0}
 
-    @app.post("/items/", response_model=Item, tags=["items", "include_in_mcp"], status_code=201)
+    @app.post("/items/", response_model=Item, tags=["items"], status_code=201)
     async def create_item(item: Item = Body(..., description="The item to create")):
         """Create a new item in the database."""
         return item
 
-    @app.put("/items/{item_id}", response_model=Item, tags=["items", "include_in_mcp"])
+    @app.put("/items/{item_id}", response_model=Item, tags=["items"])
     async def update_item(
         item_id: int = Path(..., description="The ID of the item to update"),
         item: Item = Body(..., description="The updated item data"),
@@ -63,7 +63,7 @@ def complex_app():
         item.id = item_id
         return item
 
-    @app.delete("/items/{item_id}", tags=["items", "include_in_mcp"])
+    @app.delete("/items/{item_id}", tags=["items"])
     async def delete_item(item_id: int = Path(..., description="The ID of the item to delete")):
         """Delete an item from the database."""
         return {"message": "Item deleted successfully"}

--- a/tests/test_http_tools.py
+++ b/tests/test_http_tools.py
@@ -32,7 +32,7 @@ def complex_app():
         version="0.1.0",
     )
 
-    @app.get("/items/", response_model=List[Item], tags=["items"])
+    @app.get("/items/", response_model=List[Item], tags=["items", "include_in_mcp"])
     async def list_items(
         skip: int = Query(0, description="Number of items to skip"),
         limit: int = Query(10, description="Max number of items to return"),
@@ -41,7 +41,7 @@ def complex_app():
         """List all items with pagination and sorting options."""
         return []
 
-    @app.get("/items/{item_id}", response_model=Item, tags=["items"])
+    @app.get("/items/{item_id}", response_model=Item, tags=["items", "include_in_mcp"])
     async def read_item(
         item_id: int = Path(..., description="The ID of the item to retrieve"),
         include_details: bool = Query(False, description="Include additional details"),
@@ -49,12 +49,12 @@ def complex_app():
         """Get a specific item by its ID with optional details."""
         return {"id": item_id, "name": "Test Item", "price": 10.0}
 
-    @app.post("/items/", response_model=Item, tags=["items"], status_code=201)
+    @app.post("/items/", response_model=Item, tags=["items", "include_in_mcp"], status_code=201)
     async def create_item(item: Item = Body(..., description="The item to create")):
         """Create a new item in the database."""
         return item
 
-    @app.put("/items/{item_id}", response_model=Item, tags=["items"])
+    @app.put("/items/{item_id}", response_model=Item, tags=["items", "include_in_mcp"])
     async def update_item(
         item_id: int = Path(..., description="The ID of the item to update"),
         item: Item = Body(..., description="The updated item data"),
@@ -63,7 +63,7 @@ def complex_app():
         item.id = item_id
         return item
 
-    @app.delete("/items/{item_id}", tags=["items"])
+    @app.delete("/items/{item_id}", tags=["items", "include_in_mcp"])
     async def delete_item(item_id: int = Path(..., description="The ID of the item to delete")):
         """Delete an item from the database."""
         return {"message": "Item deleted successfully"}

--- a/tests/test_tool_generation.py
+++ b/tests/test_tool_generation.py
@@ -53,6 +53,35 @@ def sample_app():
     return app
 
 
+@pytest.fixture
+def sample_app_with_tool_exclusions():
+    """Create a sample FastAPI app with some tools excluded from MCP."""
+    app = FastAPI(
+        title="Test API",
+        description="A test API for unit testing",
+        version="0.1.0", 
+    )
+
+    @app.get("/items/", response_model=List[Item], tags=["items"])
+    async def list_items(skip: int = 0, limit: int = 10):
+        """
+        List all items.
+
+        Returns a list of items, with pagination support.
+        """
+        return []
+
+    @app.post("/items/", response_model=Item, tags=["items", "exclude_from_mcp"])  # Added exclude tag
+    async def create_item(item: Item):
+        """
+        Create a new item.
+
+        Returns the created item.
+        """
+        return item
+
+    return app
+
 def test_tool_generation_basic(sample_app):
     """Test that MCP tools are properly generated with default settings."""
     # Create MCP server and register tools
@@ -90,6 +119,26 @@ def test_tool_generation_basic(sample_app):
     assert list_items_tool is not None, "list_items tool not found"
     assert "skip" in list_items_tool.parameters["properties"], "Expected 'skip' parameter"
     assert "limit" in list_items_tool.parameters["properties"], "Expected 'limit' parameter"
+
+
+def test_tool_generation_with_exclusions(sample_app_with_tool_exclusions):
+    """Test that tools tagged with 'exclude_from_mcp' are not registered."""
+    # Create MCP server and register tools
+    mcp_server = add_mcp_server(sample_app_with_tool_exclusions, serve_tools=True, base_url="http://localhost:8000")
+
+    # Extract tools for inspection
+    tools = mcp_server._tool_manager.list_tools()
+
+    # Should only have list_items endpoint and MCP endpoint (create_item excluded)
+    assert len(tools) == 2, f"Expected 2 tools (list_items + MCP endpoint), got {len(tools)}"
+
+    # Verify list_items endpoint is present
+    list_items_tool = next((t for t in tools if t.name == "list_items_items__get"), None)
+    assert list_items_tool is not None, "list_items tool not found"
+
+    # Verify create_item endpoint is not present (should be excluded)
+    create_item_tool = next((t for t in tools if t.name == "create_item_items__post"), None)
+    assert create_item_tool is None, "create_item tool should be excluded but was found"
 
 
 def test_tool_generation_with_full_schema(sample_app):

--- a/tests/test_tool_generation.py
+++ b/tests/test_tool_generation.py
@@ -124,7 +124,7 @@ def test_tool_generation_basic(sample_app):
 def test_tool_generation_with_exclusions(sample_app_with_tool_exclusions):
     """Test that  only tools tagged with "include_in_mcp"' are registered."""
     # Create MCP server and register tools
-    mcp_server = add_mcp_server(sample_app_with_tool_exclusions, serve_tools=True, base_url="http://localhost:8000")
+    mcp_server = add_mcp_server(sample_app_with_tool_exclusions, serve_tools=True, base_url="http://localhost:8000", create_tools_by_default = False)
 
     # Extract tools for inspection
     tools = mcp_server._tool_manager.list_tools()

--- a/tests/test_tool_generation.py
+++ b/tests/test_tool_generation.py
@@ -23,7 +23,7 @@ def sample_app():
         version="0.1.0",
     )
 
-    @app.get("/items/", response_model=List[Item], tags=["items"])
+    @app.get("/items/", response_model=List[Item], tags=["items","include_in_mcp"])
     async def list_items(skip: int = 0, limit: int = 10):
         """
         List all items.
@@ -32,7 +32,7 @@ def sample_app():
         """
         return []
 
-    @app.get("/items/{item_id}", response_model=Item, tags=["items"])
+    @app.get("/items/{item_id}", response_model=Item, tags=["items","include_in_mcp"])
     async def read_item(item_id: int):
         """
         Get a specific item by ID.
@@ -41,7 +41,7 @@ def sample_app():
         """
         return {"id": item_id, "name": "Test Item", "price": 0.0}
 
-    @app.post("/items/", response_model=Item, tags=["items"])
+    @app.post("/items/", response_model=Item, tags=["items", "include_in_mcp"])
     async def create_item(item: Item):
         """
         Create a new item.
@@ -62,7 +62,7 @@ def sample_app_with_tool_exclusions():
         version="0.1.0", 
     )
 
-    @app.get("/items/", response_model=List[Item], tags=["items"])
+    @app.get("/items/", response_model=List[Item], tags=["items", "include_in_mcp"])
     async def list_items(skip: int = 0, limit: int = 10):
         """
         List all items.
@@ -71,7 +71,7 @@ def sample_app_with_tool_exclusions():
         """
         return []
 
-    @app.post("/items/", response_model=Item, tags=["items", "exclude_from_mcp"])  # Added exclude tag
+    @app.post("/items/", response_model=Item, tags=["items"])
     async def create_item(item: Item):
         """
         Create a new item.
@@ -122,7 +122,7 @@ def test_tool_generation_basic(sample_app):
 
 
 def test_tool_generation_with_exclusions(sample_app_with_tool_exclusions):
-    """Test that tools tagged with 'exclude_from_mcp' are not registered."""
+    """Test that  only tools tagged with "include_in_mcp"' are registered."""
     # Create MCP server and register tools
     mcp_server = add_mcp_server(sample_app_with_tool_exclusions, serve_tools=True, base_url="http://localhost:8000")
 
@@ -130,7 +130,7 @@ def test_tool_generation_with_exclusions(sample_app_with_tool_exclusions):
     tools = mcp_server._tool_manager.list_tools()
 
     # Should only have list_items endpoint and MCP endpoint (create_item excluded)
-    assert len(tools) == 2, f"Expected 2 tools (list_items + MCP endpoint), got {len(tools)}"
+    assert len(tools) ==2, f"Expected 2 tools (list_items + MCP endpoint), got {len(tools)}"
 
     # Verify list_items endpoint is present
     list_items_tool = next((t for t in tools if t.name == "list_items_items__get"), None)


### PR DESCRIPTION
There are scenarios where we do not want to allow all paths on our FastAPI spec to be available to MCP clients-
This PR will create an 'opt-in' tag for paths, that when set, will prevent the path from being registered as a tool on our MCP server.