### PR TITLE
Feature/response models

### DIFF
--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -42,24 +42,17 @@ def resolve_schema_references(
         # Standard OpenAPI references are in the format "#/components/schemas/ModelName"
         if ref_path.startswith("#/components/schemas/"):
             model_name = ref_path.split("/")[-1]
-            if (
-                "components" in openapi_schema
-                and "schemas" in openapi_schema["components"]
-            ):
+            if "components" in openapi_schema and "schemas" in openapi_schema["components"]:
                 if model_name in openapi_schema["components"]["schemas"]:
                     # Replace with the resolved schema
-                    ref_schema = openapi_schema["components"]["schemas"][
-                        model_name
-                    ].copy()
+                    ref_schema = openapi_schema["components"]["schemas"][model_name].copy()
 
                     if top_schema is not None:
                         # Create the $defs key if it doesn't exist
                         if "$defs" not in top_schema:
                             top_schema["$defs"] = {}
 
-                        ref_schema = resolve_schema_references(
-                            ref_schema, openapi_schema, top_schema=top_schema
-                        )
+                        ref_schema = resolve_schema_references(ref_schema, openapi_schema, top_schema=top_schema)
 
                         # Create the definition reference
                         top_schema["$defs"][model_name] = ref_schema
@@ -76,16 +69,12 @@ def resolve_schema_references(
     for key in ["anyOf", "oneOf", "allOf"]:
         if key in schema:
             for index, item in enumerate(schema[key]):
-                item = resolve_schema_references(
-                    item, openapi_schema, top_schema=top_schema
-                )
+                item = resolve_schema_references(item, openapi_schema, top_schema=top_schema)
                 schema[key][index] = item
 
     # Handle array items
     if "type" in schema and schema["type"] == "array" and "items" in schema:
-        schema["items"] = resolve_schema_references(
-            schema["items"], openapi_schema, top_schema=top_schema
-        )
+        schema["items"] = resolve_schema_references(schema["items"], openapi_schema, top_schema=top_schema)
 
     # Handle object properties
     if "properties" in schema:
@@ -264,9 +253,7 @@ def create_http_tool(
         responses_to_include = responses
         if not describe_all_responses and success_response:
             # If we're not describing all responses, only include the success response
-            success_code = next(
-                (code for code in success_codes if str(code) in responses), None
-            )
+            success_code = next((code for code in success_codes if str(code) in responses), None)
             if success_code:
                 responses_to_include = {str(success_code): success_response}
 
@@ -287,9 +274,7 @@ def create_http_tool(
                         response_info += f"\nContent-Type: {content_type}"
 
                         # Resolve any schema references
-                        resolved_schema = resolve_schema_references(
-                            schema, openapi_schema
-                        )
+                        resolved_schema = resolve_schema_references(schema, openapi_schema)
 
                         # Clean the schema for display
                         display_schema = clean_schema_for_display(resolved_schema)
@@ -304,16 +289,10 @@ def create_http_tool(
                                 model_name = ref_path.split("/")[-1]
                                 response_info += f"\nModel: {model_name}"
                                 # Try to get examples from the model
-                                model_examples = extract_model_examples_from_components(
-                                    model_name, openapi_schema
-                                )
+                                model_examples = extract_model_examples_from_components(model_name, openapi_schema)
 
                         # Check if this is an array of items
-                        if (
-                            schema.get("type") == "array"
-                            and "items" in schema
-                            and "$ref" in schema["items"]
-                        ):
+                        if schema.get("type") == "array" and "items" in schema and "$ref" in schema["items"]:
                             items_ref_path = schema["items"]["$ref"]
                             if items_ref_path.startswith("#/components/schemas/"):
                                 items_model_name = items_ref_path.split("/")[-1]
@@ -328,17 +307,13 @@ def create_http_tool(
                         # Otherwise, try to create an example from the response definitions
                         elif "examples" in response_data:
                             # Use examples directly from response definition
-                            for example_key, example_data in response_data[
-                                "examples"
-                            ].items():
+                            for example_key, example_data in response_data["examples"].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
                         # If content has examples
                         elif "examples" in content_data:
-                            for example_key, example_data in content_data[
-                                "examples"
-                            ].items():
+                            for example_key, example_data in content_data["examples"].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
@@ -376,9 +351,7 @@ def create_http_tool(
                             response_info += "\n```"
                         # Otherwise generate an example from the schema
                         else:
-                            generated_example = generate_example_from_schema(
-                                display_schema, model_name
-                            )
+                            generated_example = generate_example_from_schema(display_schema, model_name)
                             if generated_example:
                                 response_info += "\n\n**Example Response:**\n```json\n"
                                 response_info += json.dumps(generated_example, indent=2)
@@ -387,13 +360,12 @@ def create_http_tool(
                         # Only include full schema information if requested
                         if describe_full_response_schema:
                             # Format schema information based on its type
-                            if (
-                                display_schema.get("type") == "array"
-                                and "items" in display_schema
-                            ):
+                            if display_schema.get("type") == "array" and "items" in display_schema:
                                 items_schema = display_schema["items"]
 
-                                response_info += "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
+                                response_info += (
+                                    "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
+                                )
                                 response_info += json.dumps(items_schema, indent=2)
                                 response_info += "\n```"
                             elif "properties" in display_schema:
@@ -518,19 +490,13 @@ def create_http_tool(
             if method.lower() == "get":
                 response = await client.get(url, params=query, headers=headers)
             elif method.lower() == "post":
-                response = await client.post(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.post(url, params=query, headers=headers, json=body)
             elif method.lower() == "put":
-                response = await client.put(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.put(url, params=query, headers=headers, json=body)
             elif method.lower() == "delete":
                 response = await client.delete(url, params=query, headers=headers)
             elif method.lower() == "patch":
-                response = await client.patch(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.patch(url, params=query, headers=headers, json=body)
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
@@ -559,9 +525,7 @@ def create_http_tool(
     http_tool_function._input_schema = input_schema  # type: ignore
 
     # Add tool to the MCP server with the enhanced schema
-    tool = mcp_server._tool_manager.add_tool(
-        http_tool_function, name=operation_id, description=tool_description
-    )
+    tool = mcp_server._tool_manager.add_tool(http_tool_function, name=operation_id, description=tool_description)
 
     # Update the tool's parameters to use our custom schema instead of the auto-generated one
     tool.parameters = input_schema
@@ -580,10 +544,7 @@ def extract_model_examples_from_components(
     Returns:
         List of example dictionaries if found, None otherwise
     """
-    if (
-        "components" not in openapi_schema
-        or "schemas" not in openapi_schema["components"]
-    ):
+    if "components" not in openapi_schema or "schemas" not in openapi_schema["components"]:
         return None
 
     if model_name not in openapi_schema["components"]["schemas"]:
@@ -604,9 +565,7 @@ def extract_model_examples_from_components(
     return examples
 
 
-def generate_example_from_schema(
-    schema: Dict[str, Any], model_name: Optional[str] = None
-) -> Any:
+def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[str] = None) -> Any:
     """
     Generate a simple example response from a JSON schema.
 

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -12,12 +12,13 @@ import httpx
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from mcp.server.fastmcp import FastMCP
-from pydantic import Field
 
 logger = logging.getLogger("fastapi_mcp")
 
 
-def resolve_schema_references(schema: Dict[str, Any], openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+def resolve_schema_references(
+    schema: Dict[str, Any], openapi_schema: Dict[str, Any], top_schema=None
+) -> Dict[str, Any]:
     """
     Resolve schema references in OpenAPI schemas.
 
@@ -31,28 +32,66 @@ def resolve_schema_references(schema: Dict[str, Any], openapi_schema: Dict[str, 
     # Make a copy to avoid modifying the input schema
     schema = schema.copy()
 
+    # Create a a definnition prefix for the schema
+    def_prefix = "#/$defs/"
+
     # Handle $ref directly in the schema
     if "$ref" in schema:
         ref_path = schema["$ref"]
         # Standard OpenAPI references are in the format "#/components/schemas/ModelName"
         if ref_path.startswith("#/components/schemas/"):
             model_name = ref_path.split("/")[-1]
-            if "components" in openapi_schema and "schemas" in openapi_schema["components"]:
+            if (
+                "components" in openapi_schema
+                and "schemas" in openapi_schema["components"]
+            ):
                 if model_name in openapi_schema["components"]["schemas"]:
                     # Replace with the resolved schema
-                    ref_schema = openapi_schema["components"]["schemas"][model_name].copy()
-                    # Remove the $ref key and merge with the original schema
-                    schema.pop("$ref")
-                    schema.update(ref_schema)
+                    ref_schema = openapi_schema["components"]["schemas"][
+                        model_name
+                    ].copy()
+
+                    if top_schema is not None:
+                        # Create the $defs key if it doesn't exist
+                        if "$defs" not in top_schema:
+                            top_schema["$defs"] = {}
+
+                        ref_schema = resolve_schema_references(
+                            ref_schema, openapi_schema, top_schema=top_schema
+                        )
+
+                        # Create the definition reference
+                        top_schema["$defs"][model_name] = ref_schema
+
+                        # Update the schema with the definition reference
+                        schema["$ref"] = def_prefix + model_name
+                    else:
+                        # Update the schema with the definition reference
+                        schema.pop("$ref")
+                        schema.update(ref_schema)
+                        top_schema = schema
+
+    # Handle anyOf, oneOf, allOf
+    for key in ["anyOf", "oneOf", "allOf"]:
+        if key in schema:
+            for index, item in enumerate(schema[key]):
+                item = resolve_schema_references(
+                    item, openapi_schema, top_schema=top_schema
+                )
+                schema[key][index] = item
 
     # Handle array items
     if "type" in schema and schema["type"] == "array" and "items" in schema:
-        schema["items"] = resolve_schema_references(schema["items"], openapi_schema)
+        schema["items"] = resolve_schema_references(
+            schema["items"], openapi_schema, top_schema=top_schema
+        )
 
     # Handle object properties
     if "properties" in schema:
         for prop_name, prop_schema in schema["properties"].items():
-            schema["properties"][prop_name] = resolve_schema_references(prop_schema, openapi_schema)
+            schema["properties"][prop_name] = resolve_schema_references(
+                prop_schema, openapi_schema, top_schema=top_schema
+            )
 
     return schema
 
@@ -72,9 +111,6 @@ def clean_schema_for_display(schema: Dict[str, Any]) -> Dict[str, Any]:
 
     # Remove common internal fields that are not helpful for LLMs
     fields_to_remove = [
-        "allOf",
-        "anyOf",
-        "oneOf",
         "nullable",
         "discriminator",
         "readOnly",
@@ -227,7 +263,9 @@ def create_http_tool(
         responses_to_include = responses
         if not describe_all_responses and success_response:
             # If we're not describing all responses, only include the success response
-            success_code = next((code for code in success_codes if str(code) in responses), None)
+            success_code = next(
+                (code for code in success_codes if str(code) in responses), None
+            )
             if success_code:
                 responses_to_include = {str(success_code): success_response}
 
@@ -248,7 +286,9 @@ def create_http_tool(
                         response_info += f"\nContent-Type: {content_type}"
 
                         # Resolve any schema references
-                        resolved_schema = resolve_schema_references(schema, openapi_schema)
+                        resolved_schema = resolve_schema_references(
+                            schema, openapi_schema
+                        )
 
                         # Clean the schema for display
                         display_schema = clean_schema_for_display(resolved_schema)
@@ -263,10 +303,16 @@ def create_http_tool(
                                 model_name = ref_path.split("/")[-1]
                                 response_info += f"\nModel: {model_name}"
                                 # Try to get examples from the model
-                                model_examples = extract_model_examples_from_components(model_name, openapi_schema)
+                                model_examples = extract_model_examples_from_components(
+                                    model_name, openapi_schema
+                                )
 
                         # Check if this is an array of items
-                        if schema.get("type") == "array" and "items" in schema and "$ref" in schema["items"]:
+                        if (
+                            schema.get("type") == "array"
+                            and "items" in schema
+                            and "$ref" in schema["items"]
+                        ):
                             items_ref_path = schema["items"]["$ref"]
                             if items_ref_path.startswith("#/components/schemas/"):
                                 items_model_name = items_ref_path.split("/")[-1]
@@ -281,13 +327,17 @@ def create_http_tool(
                         # Otherwise, try to create an example from the response definitions
                         elif "examples" in response_data:
                             # Use examples directly from response definition
-                            for example_key, example_data in response_data["examples"].items():
+                            for example_key, example_data in response_data[
+                                "examples"
+                            ].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
                         # If content has examples
                         elif "examples" in content_data:
-                            for example_key, example_data in content_data["examples"].items():
+                            for example_key, example_data in content_data[
+                                "examples"
+                            ].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
@@ -325,7 +375,9 @@ def create_http_tool(
                             response_info += "\n```"
                         # Otherwise generate an example from the schema
                         else:
-                            generated_example = generate_example_from_schema(display_schema, model_name)
+                            generated_example = generate_example_from_schema(
+                                display_schema, model_name
+                            )
                             if generated_example:
                                 response_info += "\n\n**Example Response:**\n```json\n"
                                 response_info += json.dumps(generated_example, indent=2)
@@ -334,12 +386,13 @@ def create_http_tool(
                         # Only include full schema information if requested
                         if describe_full_response_schema:
                             # Format schema information based on its type
-                            if display_schema.get("type") == "array" and "items" in display_schema:
+                            if (
+                                display_schema.get("type") == "array"
+                                and "items" in display_schema
+                            ):
                                 items_schema = display_schema["items"]
 
-                                response_info += (
-                                    "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
-                                )
+                                response_info += "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
                                 response_info += json.dumps(items_schema, indent=2)
                                 response_info += "\n```"
                             elif "properties" in display_schema:
@@ -436,7 +489,7 @@ def create_http_tool(
             required_props.append(param_name)
 
     # Function to dynamically call the API endpoint
-    async def http_tool_function(kwargs: Dict[str, Any] = Field(default_factory=dict)):
+    async def http_tool_function(**kwargs):
         # Prepare URL with path parameters
         url = f"{base_url}{path}"
         for param_name, _ in path_params:
@@ -464,13 +517,21 @@ def create_http_tool(
             if method.lower() == "get":
                 response = await client.get(url, params=query, headers=headers)
             elif method.lower() == "post":
-                response = await client.post(url, params=query, headers=headers, json=body)
+                response = await client.post(
+                    url, params=query, headers=headers, json=body
+                )
             elif method.lower() == "put":
-                response = await client.put(url, params=query, headers=headers, json=body)
+                response = await client.put(
+                    url, params=query, headers=headers, json=body
+                )
             elif method.lower() == "delete":
-                response = await client.delete(url, params=query, headers=headers)
+                response = await client.delete(
+                    url, params=query, headers=headers, json=body
+                )
             elif method.lower() == "patch":
-                response = await client.patch(url, params=query, headers=headers, json=body)
+                response = await client.patch(
+                    url, params=query, headers=headers, json=body
+                )
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
@@ -481,7 +542,11 @@ def create_http_tool(
             return response.text
 
     # Create a proper input schema for the tool
-    input_schema = {"type": "object", "properties": properties, "title": f"{operation_id}Arguments"}
+    input_schema = {
+        "type": "object",
+        "properties": properties,
+        "title": f"{operation_id}Arguments",
+    }
 
     if required_props:
         input_schema["required"] = required_props
@@ -495,7 +560,9 @@ def create_http_tool(
     http_tool_function._input_schema = input_schema  # type: ignore
 
     # Add tool to the MCP server with the enhanced schema
-    tool = mcp_server._tool_manager.add_tool(http_tool_function, name=operation_id, description=tool_description)
+    tool = mcp_server._tool_manager.add_tool(
+        http_tool_function, name=operation_id, description=tool_description
+    )
 
     # Update the tool's parameters to use our custom schema instead of the auto-generated one
     tool.parameters = input_schema
@@ -514,7 +581,10 @@ def extract_model_examples_from_components(
     Returns:
         List of example dictionaries if found, None otherwise
     """
-    if "components" not in openapi_schema or "schemas" not in openapi_schema["components"]:
+    if (
+        "components" not in openapi_schema
+        or "schemas" not in openapi_schema["components"]
+    ):
         return None
 
     if model_name not in openapi_schema["components"]["schemas"]:
@@ -535,7 +605,9 @@ def extract_model_examples_from_components(
     return examples
 
 
-def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[str] = None) -> Any:
+def generate_example_from_schema(
+    schema: Dict[str, Any], model_name: Optional[str] = None
+) -> Any:
     """
     Generate a simple example response from a JSON schema.
 
@@ -561,7 +633,15 @@ def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[st
         }
     elif model_name == "HTTPValidationError":
         # Create a realistic validation error example
-        return {"detail": [{"loc": ["body", "name"], "msg": "field required", "type": "value_error.missing"}]}
+        return {
+            "detail": [
+                {
+                    "loc": ["body", "name"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                }
+            ]
+        }
 
     # Handle different types
     schema_type = schema.get("type")

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -461,7 +461,7 @@ def create_http_tool(
             required_props.append(param_name)
 
     # Function to dynamically call the API endpoint
-    async def http_tool_function(**kwargs):
+        async def http_tool_function(kwargs: Dict[str, Any] = Field(default_factory=dict)):
         # Prepare URL with path parameters
         url = f"{base_url}{path}"
         for param_name, _ in path_params:
@@ -493,7 +493,7 @@ def create_http_tool(
             elif method.lower() == "put":
                 response = await client.put(url, params=query, headers=headers, json=body)
             elif method.lower() == "delete":
-                response = await client.delete(url, params=query, headers=headers, json=body)
+                response = await client.delete(url, params=query, headers=headers)
             elif method.lower() == "patch":
                 response = await client.patch(url, params=query, headers=headers, json=body)
             else:
@@ -506,11 +506,7 @@ def create_http_tool(
             return response.text
 
     # Create a proper input schema for the tool
-    input_schema = {
-        "type": "object",
-        "properties": properties,
-        "title": f"{operation_id}Arguments",
-    }
+    input_schema = {"type": "object", "properties": properties, "title": f"{operation_id}Arguments"}
 
     if required_props:
         input_schema["required"] = required_props
@@ -590,15 +586,7 @@ def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[st
         }
     elif model_name == "HTTPValidationError":
         # Create a realistic validation error example
-        return {
-            "detail": [
-                {
-                    "loc": ["body", "name"],
-                    "msg": "field required",
-                    "type": "value_error.missing",
-                }
-            ]
-        }
+        return {"detail": [{"loc": ["body", "name"], "msg": "field required", "type": "value_error.missing"}]}
 
     # Handle different types
     schema_type = schema.get("type")

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -12,6 +12,7 @@ import httpx
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
 
 logger = logging.getLogger("fastapi_mcp")
 
@@ -41,17 +42,24 @@ def resolve_schema_references(
         # Standard OpenAPI references are in the format "#/components/schemas/ModelName"
         if ref_path.startswith("#/components/schemas/"):
             model_name = ref_path.split("/")[-1]
-            if "components" in openapi_schema and "schemas" in openapi_schema["components"]:
+            if (
+                "components" in openapi_schema
+                and "schemas" in openapi_schema["components"]
+            ):
                 if model_name in openapi_schema["components"]["schemas"]:
                     # Replace with the resolved schema
-                    ref_schema = openapi_schema["components"]["schemas"][model_name].copy()
+                    ref_schema = openapi_schema["components"]["schemas"][
+                        model_name
+                    ].copy()
 
                     if top_schema is not None:
                         # Create the $defs key if it doesn't exist
                         if "$defs" not in top_schema:
                             top_schema["$defs"] = {}
 
-                        ref_schema = resolve_schema_references(ref_schema, openapi_schema, top_schema=top_schema)
+                        ref_schema = resolve_schema_references(
+                            ref_schema, openapi_schema, top_schema=top_schema
+                        )
 
                         # Create the definition reference
                         top_schema["$defs"][model_name] = ref_schema
@@ -68,12 +76,16 @@ def resolve_schema_references(
     for key in ["anyOf", "oneOf", "allOf"]:
         if key in schema:
             for index, item in enumerate(schema[key]):
-                item = resolve_schema_references(item, openapi_schema, top_schema=top_schema)
+                item = resolve_schema_references(
+                    item, openapi_schema, top_schema=top_schema
+                )
                 schema[key][index] = item
 
     # Handle array items
     if "type" in schema and schema["type"] == "array" and "items" in schema:
-        schema["items"] = resolve_schema_references(schema["items"], openapi_schema, top_schema=top_schema)
+        schema["items"] = resolve_schema_references(
+            schema["items"], openapi_schema, top_schema=top_schema
+        )
 
     # Handle object properties
     if "properties" in schema:
@@ -252,7 +264,9 @@ def create_http_tool(
         responses_to_include = responses
         if not describe_all_responses and success_response:
             # If we're not describing all responses, only include the success response
-            success_code = next((code for code in success_codes if str(code) in responses), None)
+            success_code = next(
+                (code for code in success_codes if str(code) in responses), None
+            )
             if success_code:
                 responses_to_include = {str(success_code): success_response}
 
@@ -273,7 +287,9 @@ def create_http_tool(
                         response_info += f"\nContent-Type: {content_type}"
 
                         # Resolve any schema references
-                        resolved_schema = resolve_schema_references(schema, openapi_schema)
+                        resolved_schema = resolve_schema_references(
+                            schema, openapi_schema
+                        )
 
                         # Clean the schema for display
                         display_schema = clean_schema_for_display(resolved_schema)
@@ -288,10 +304,16 @@ def create_http_tool(
                                 model_name = ref_path.split("/")[-1]
                                 response_info += f"\nModel: {model_name}"
                                 # Try to get examples from the model
-                                model_examples = extract_model_examples_from_components(model_name, openapi_schema)
+                                model_examples = extract_model_examples_from_components(
+                                    model_name, openapi_schema
+                                )
 
                         # Check if this is an array of items
-                        if schema.get("type") == "array" and "items" in schema and "$ref" in schema["items"]:
+                        if (
+                            schema.get("type") == "array"
+                            and "items" in schema
+                            and "$ref" in schema["items"]
+                        ):
                             items_ref_path = schema["items"]["$ref"]
                             if items_ref_path.startswith("#/components/schemas/"):
                                 items_model_name = items_ref_path.split("/")[-1]
@@ -306,13 +328,17 @@ def create_http_tool(
                         # Otherwise, try to create an example from the response definitions
                         elif "examples" in response_data:
                             # Use examples directly from response definition
-                            for example_key, example_data in response_data["examples"].items():
+                            for example_key, example_data in response_data[
+                                "examples"
+                            ].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
                         # If content has examples
                         elif "examples" in content_data:
-                            for example_key, example_data in content_data["examples"].items():
+                            for example_key, example_data in content_data[
+                                "examples"
+                            ].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
@@ -350,7 +376,9 @@ def create_http_tool(
                             response_info += "\n```"
                         # Otherwise generate an example from the schema
                         else:
-                            generated_example = generate_example_from_schema(display_schema, model_name)
+                            generated_example = generate_example_from_schema(
+                                display_schema, model_name
+                            )
                             if generated_example:
                                 response_info += "\n\n**Example Response:**\n```json\n"
                                 response_info += json.dumps(generated_example, indent=2)
@@ -359,12 +387,13 @@ def create_http_tool(
                         # Only include full schema information if requested
                         if describe_full_response_schema:
                             # Format schema information based on its type
-                            if display_schema.get("type") == "array" and "items" in display_schema:
+                            if (
+                                display_schema.get("type") == "array"
+                                and "items" in display_schema
+                            ):
                                 items_schema = display_schema["items"]
 
-                                response_info += (
-                                    "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
-                                )
+                                response_info += "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
                                 response_info += json.dumps(items_schema, indent=2)
                                 response_info += "\n```"
                             elif "properties" in display_schema:
@@ -461,7 +490,7 @@ def create_http_tool(
             required_props.append(param_name)
 
     # Function to dynamically call the API endpoint
-        async def http_tool_function(kwargs: Dict[str, Any] = Field(default_factory=dict)):
+    async def http_tool_function(kwargs: Dict[str, Any] = Field(default_factory=dict)):
         # Prepare URL with path parameters
         url = f"{base_url}{path}"
         for param_name, _ in path_params:
@@ -489,13 +518,19 @@ def create_http_tool(
             if method.lower() == "get":
                 response = await client.get(url, params=query, headers=headers)
             elif method.lower() == "post":
-                response = await client.post(url, params=query, headers=headers, json=body)
+                response = await client.post(
+                    url, params=query, headers=headers, json=body
+                )
             elif method.lower() == "put":
-                response = await client.put(url, params=query, headers=headers, json=body)
+                response = await client.put(
+                    url, params=query, headers=headers, json=body
+                )
             elif method.lower() == "delete":
                 response = await client.delete(url, params=query, headers=headers)
             elif method.lower() == "patch":
-                response = await client.patch(url, params=query, headers=headers, json=body)
+                response = await client.patch(
+                    url, params=query, headers=headers, json=body
+                )
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
@@ -506,7 +541,11 @@ def create_http_tool(
             return response.text
 
     # Create a proper input schema for the tool
-    input_schema = {"type": "object", "properties": properties, "title": f"{operation_id}Arguments"}
+    input_schema = {
+        "type": "object",
+        "properties": properties,
+        "title": f"{operation_id}Arguments",
+    }
 
     if required_props:
         input_schema["required"] = required_props
@@ -520,7 +559,9 @@ def create_http_tool(
     http_tool_function._input_schema = input_schema  # type: ignore
 
     # Add tool to the MCP server with the enhanced schema
-    tool = mcp_server._tool_manager.add_tool(http_tool_function, name=operation_id, description=tool_description)
+    tool = mcp_server._tool_manager.add_tool(
+        http_tool_function, name=operation_id, description=tool_description
+    )
 
     # Update the tool's parameters to use our custom schema instead of the auto-generated one
     tool.parameters = input_schema
@@ -539,7 +580,10 @@ def extract_model_examples_from_components(
     Returns:
         List of example dictionaries if found, None otherwise
     """
-    if "components" not in openapi_schema or "schemas" not in openapi_schema["components"]:
+    if (
+        "components" not in openapi_schema
+        or "schemas" not in openapi_schema["components"]
+    ):
         return None
 
     if model_name not in openapi_schema["components"]["schemas"]:
@@ -560,7 +604,9 @@ def extract_model_examples_from_components(
     return examples
 
 
-def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[str] = None) -> Any:
+def generate_example_from_schema(
+    schema: Dict[str, Any], model_name: Optional[str] = None
+) -> Any:
     """
     Generate a simple example response from a JSON schema.
 
@@ -586,7 +632,15 @@ def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[st
         }
     elif model_name == "HTTPValidationError":
         # Create a realistic validation error example
-        return {"detail": [{"loc": ["body", "name"], "msg": "field required", "type": "value_error.missing"}]}
+        return {
+            "detail": [
+                {
+                    "loc": ["body", "name"],
+                    "msg": "field required",
+                    "type": "value_error.missing",
+                }
+            ]
+        }
 
     # Handle different types
     schema_type = schema.get("type")

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -41,24 +41,17 @@ def resolve_schema_references(
         # Standard OpenAPI references are in the format "#/components/schemas/ModelName"
         if ref_path.startswith("#/components/schemas/"):
             model_name = ref_path.split("/")[-1]
-            if (
-                "components" in openapi_schema
-                and "schemas" in openapi_schema["components"]
-            ):
+            if "components" in openapi_schema and "schemas" in openapi_schema["components"]:
                 if model_name in openapi_schema["components"]["schemas"]:
                     # Replace with the resolved schema
-                    ref_schema = openapi_schema["components"]["schemas"][
-                        model_name
-                    ].copy()
+                    ref_schema = openapi_schema["components"]["schemas"][model_name].copy()
 
                     if top_schema is not None:
                         # Create the $defs key if it doesn't exist
                         if "$defs" not in top_schema:
                             top_schema["$defs"] = {}
 
-                        ref_schema = resolve_schema_references(
-                            ref_schema, openapi_schema, top_schema=top_schema
-                        )
+                        ref_schema = resolve_schema_references(ref_schema, openapi_schema, top_schema=top_schema)
 
                         # Create the definition reference
                         top_schema["$defs"][model_name] = ref_schema
@@ -75,16 +68,12 @@ def resolve_schema_references(
     for key in ["anyOf", "oneOf", "allOf"]:
         if key in schema:
             for index, item in enumerate(schema[key]):
-                item = resolve_schema_references(
-                    item, openapi_schema, top_schema=top_schema
-                )
+                item = resolve_schema_references(item, openapi_schema, top_schema=top_schema)
                 schema[key][index] = item
 
     # Handle array items
     if "type" in schema and schema["type"] == "array" and "items" in schema:
-        schema["items"] = resolve_schema_references(
-            schema["items"], openapi_schema, top_schema=top_schema
-        )
+        schema["items"] = resolve_schema_references(schema["items"], openapi_schema, top_schema=top_schema)
 
     # Handle object properties
     if "properties" in schema:
@@ -263,9 +252,7 @@ def create_http_tool(
         responses_to_include = responses
         if not describe_all_responses and success_response:
             # If we're not describing all responses, only include the success response
-            success_code = next(
-                (code for code in success_codes if str(code) in responses), None
-            )
+            success_code = next((code for code in success_codes if str(code) in responses), None)
             if success_code:
                 responses_to_include = {str(success_code): success_response}
 
@@ -286,9 +273,7 @@ def create_http_tool(
                         response_info += f"\nContent-Type: {content_type}"
 
                         # Resolve any schema references
-                        resolved_schema = resolve_schema_references(
-                            schema, openapi_schema
-                        )
+                        resolved_schema = resolve_schema_references(schema, openapi_schema)
 
                         # Clean the schema for display
                         display_schema = clean_schema_for_display(resolved_schema)
@@ -303,16 +288,10 @@ def create_http_tool(
                                 model_name = ref_path.split("/")[-1]
                                 response_info += f"\nModel: {model_name}"
                                 # Try to get examples from the model
-                                model_examples = extract_model_examples_from_components(
-                                    model_name, openapi_schema
-                                )
+                                model_examples = extract_model_examples_from_components(model_name, openapi_schema)
 
                         # Check if this is an array of items
-                        if (
-                            schema.get("type") == "array"
-                            and "items" in schema
-                            and "$ref" in schema["items"]
-                        ):
+                        if schema.get("type") == "array" and "items" in schema and "$ref" in schema["items"]:
                             items_ref_path = schema["items"]["$ref"]
                             if items_ref_path.startswith("#/components/schemas/"):
                                 items_model_name = items_ref_path.split("/")[-1]
@@ -327,17 +306,13 @@ def create_http_tool(
                         # Otherwise, try to create an example from the response definitions
                         elif "examples" in response_data:
                             # Use examples directly from response definition
-                            for example_key, example_data in response_data[
-                                "examples"
-                            ].items():
+                            for example_key, example_data in response_data["examples"].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
                         # If content has examples
                         elif "examples" in content_data:
-                            for example_key, example_data in content_data[
-                                "examples"
-                            ].items():
+                            for example_key, example_data in content_data["examples"].items():
                                 if "value" in example_data:
                                     example_response = example_data["value"]
                                     break
@@ -375,9 +350,7 @@ def create_http_tool(
                             response_info += "\n```"
                         # Otherwise generate an example from the schema
                         else:
-                            generated_example = generate_example_from_schema(
-                                display_schema, model_name
-                            )
+                            generated_example = generate_example_from_schema(display_schema, model_name)
                             if generated_example:
                                 response_info += "\n\n**Example Response:**\n```json\n"
                                 response_info += json.dumps(generated_example, indent=2)
@@ -386,13 +359,12 @@ def create_http_tool(
                         # Only include full schema information if requested
                         if describe_full_response_schema:
                             # Format schema information based on its type
-                            if (
-                                display_schema.get("type") == "array"
-                                and "items" in display_schema
-                            ):
+                            if display_schema.get("type") == "array" and "items" in display_schema:
                                 items_schema = display_schema["items"]
 
-                                response_info += "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
+                                response_info += (
+                                    "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
+                                )
                                 response_info += json.dumps(items_schema, indent=2)
                                 response_info += "\n```"
                             elif "properties" in display_schema:
@@ -517,21 +489,13 @@ def create_http_tool(
             if method.lower() == "get":
                 response = await client.get(url, params=query, headers=headers)
             elif method.lower() == "post":
-                response = await client.post(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.post(url, params=query, headers=headers, json=body)
             elif method.lower() == "put":
-                response = await client.put(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.put(url, params=query, headers=headers, json=body)
             elif method.lower() == "delete":
-                response = await client.delete(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.delete(url, params=query, headers=headers, json=body)
             elif method.lower() == "patch":
-                response = await client.patch(
-                    url, params=query, headers=headers, json=body
-                )
+                response = await client.patch(url, params=query, headers=headers, json=body)
             else:
                 raise ValueError(f"Unsupported HTTP method: {method}")
 
@@ -560,9 +524,7 @@ def create_http_tool(
     http_tool_function._input_schema = input_schema  # type: ignore
 
     # Add tool to the MCP server with the enhanced schema
-    tool = mcp_server._tool_manager.add_tool(
-        http_tool_function, name=operation_id, description=tool_description
-    )
+    tool = mcp_server._tool_manager.add_tool(http_tool_function, name=operation_id, description=tool_description)
 
     # Update the tool's parameters to use our custom schema instead of the auto-generated one
     tool.parameters = input_schema
@@ -581,10 +543,7 @@ def extract_model_examples_from_components(
     Returns:
         List of example dictionaries if found, None otherwise
     """
-    if (
-        "components" not in openapi_schema
-        or "schemas" not in openapi_schema["components"]
-    ):
+    if "components" not in openapi_schema or "schemas" not in openapi_schema["components"]:
         return None
 
     if model_name not in openapi_schema["components"]["schemas"]:
@@ -605,9 +564,7 @@ def extract_model_examples_from_components(
     return examples
 
 
-def generate_example_from_schema(
-    schema: Dict[str, Any], model_name: Optional[str] = None
-) -> Any:
+def generate_example_from_schema(schema: Dict[str, Any], model_name: Optional[str] = None) -> Any:
     """
     Generate a simple example response from a JSON schema.
 


### PR DESCRIPTION
This PR modifies the `describe_full_response_schema` function to provide a more comprehensive JSON response schema. Specifically, it traces references until the entire top level response model is fully defined, and mirrors the output of pydantics `BaseModel.json_model_schema` output for a specific model.

This can become large for complex models, but seems appropriate given the name of the option.

The major reason for this change is that the original code would discard `Union` fields that get translated to `anyOf`, which were removed in the `clean_schema_for_display` function.

This PR is WIP, and needs at least two unit tests: one for `Union` fields and one for fields defined by a pydantic `BaseModel`