### PR TITLE
fix(#20): correct uv installation instructions in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ uv venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 # Install development dependencies with uv
-uv add -e ".[dev]"
+uv sync --extra dev
 
 # Alternatively, using pip
 # python -m venv venv

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ cd fastapi_mcp
 # Create a virtual environment and install dependencies with uv
 uv venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-uv add -e ".[dev]"
+uv sync --extra dev
 
 # Run tests
 uv run pytest


### PR DESCRIPTION
# Fix incorrect uv installation instructions in documentation

## Description
I encountered an issue with the development setup instructions in both CONTRIBUTING.md and README.md. The current instructions use `uv add -e ".[dev]"`, which fails with the following error:

```
error: unexpected argument '-e' found
tip: to pass '-e' as a value, use '-- -e'
```

This happens because `uv add` doesn't support the `-e` flag for editable installs, making it impossible for new contributors to set up their development environment following the current instructions.

## Changes Made
- Updated the installation command in CONTRIBUTING.md from `uv add -e ".[dev]"` to `uv sync --extra dev`
- Updated the corresponding instructions in README.md with the same correction
- Ensured the rest of the documentation remains consistent with this change

## How I Fixed It
I researched the correct uv command for installing a project with extra dependencies in editable mode. According to the [official uv documentation](https://docs.astral.sh/uv/concepts/projects/sync/#syncing-optional-dependencies), `uv sync --extra dev` is the proper command to install a project with its development dependencies. The sync command automatically installs the project in editable mode by default, which is exactly what we need for development.

## Verification Steps
To verify this fix works correctly:

1. Clone the repository: 
   ```bash
   git clone https://github.com/tadata-org/fastapi_mcp.git
   cd fastapi-mcp
   ```

2. Create a virtual environment with uv:
   ```bash
   uv venv
   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
   ```

3. Try the new command to install development dependencies:
   ```bash
   uv sync --extra dev
   ```

4. Verify the installation was successful by checking the installed packages:
   ```bash
   uv pip list
   ```

5. Further verify that the development environment is working by running the project's development tools:
   ```bash
   uv run mypy .
   uv run pytest
   ```
   All tools run successfully, confirming the development dependencies were properly installed.

6. Verify that the examples run correctly:
   ```bash
   uv run examples/simple_integration.py
   ```
   The example application starts successfully, confirming that the main package and its dependencies are properly installed and functioning.

7. For comparison, if you try the old command:
   ```bash
   uv add -e ".[dev]"
   ```
   You'll see the error mentioned above, demonstrating why this documentation update is necessary.

## Related Issues
Fixes #20
