### PR TITLE
Fix/hide handle mcp connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6]
+
+### Fixed
+- [Issue #23](https://github.com/tadata-org/fastapi_mcp/issues/23): Hide handle_mcp_connection tool.
+
 ## [0.1.5]
 
 ### Fixed

--- a/fastapi_mcp/__init__.py
+++ b/fastapi_mcp/__init__.py
@@ -4,7 +4,7 @@ FastAPI-MCP: Automatic MCP server generator for FastAPI applications.
 Created by Tadata Inc. (https://github.com/tadata-org)
 """
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 from .server import add_mcp_server, create_mcp_server, mount_mcp_server
 from .http_tools import create_mcp_tools_from_openapi

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -83,10 +83,6 @@ def create_mcp_tools_from_openapi(
             if not operation_id:
                 continue
 
-            # Skip MCP's internal tool that doesn't follow the same patterns
-            if operation_id == "handle_mcp_connection_mcp_get":
-                continue
-
             # Create MCP tool for this operation
             create_http_tool(
                 mcp_server=mcp_server,

--- a/fastapi_mcp/http_tools.py
+++ b/fastapi_mcp/http_tools.py
@@ -83,6 +83,10 @@ def create_mcp_tools_from_openapi(
             if not operation_id:
                 continue
 
+            # Skip MCP's internal tool that doesn't follow the same patterns
+            if operation_id == "handle_mcp_connection_mcp_get":
+                continue
+
             # Create MCP tool for this operation
             create_http_tool(
                 mcp_server=mcp_server,

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -87,10 +87,6 @@ def mount_mcp_server(
                 mcp_server._mcp_server.create_initialization_options(),
             )
 
-    # Mount the MCP connection handler
-    app.get(mount_path)(handle_mcp_connection)
-    app.mount(f"{mount_path}/messages/", app=sse_transport.handle_post_message)
-
     # Serve tools from the FastAPI app if requested
     if serve_tools:
         create_mcp_tools_from_openapi(
@@ -100,6 +96,11 @@ def mount_mcp_server(
             describe_all_responses=describe_all_responses,
             describe_full_response_schema=describe_full_response_schema,
         )
+    
+    # Mount the MCP connection handler
+    app.get(mount_path)(handle_mcp_connection)
+    app.mount(f"{mount_path}/messages/", app=sse_transport.handle_post_message)
+
 
 
 def add_mcp_server(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fastapi-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "Automatic MCP server generator for FastAPI applications - converts FastAPI endpoints to MCP tools for LLM integration"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ dependencies = pyproject_data["project"]["dependencies"]
 
 setup(
     name="fastapi-mcp",
-    version="0.1.5",
+    version="0.1.6",
     description="Automatic MCP server generator for FastAPI applications - converts FastAPI endpoints to MCP tools for LLM integration",
     author="Tadata Inc.",
     author_email="itay@tadata.com",

--- a/tests/test_tool_generation.py
+++ b/tests/test_tool_generation.py
@@ -71,10 +71,6 @@ def test_tool_generation_basic(sample_app):
         assert hasattr(tool, "parameters"), "Tool missing 'parameters' property"
         assert hasattr(tool, "fn_metadata"), "Tool missing 'fn_metadata' property"
 
-        # Skip MCP's internal tool that doesn't follow the same patterns
-        if tool.name == "handle_mcp_connection_mcp_get":
-            continue
-
         # With describe_all_responses=False by default, description should only include success response code
         assert "200" in tool.description, f"Expected success response code in description for {tool.name}"
         assert "422" not in tool.description, f"Expected not to see 422 response in tool description for {tool.name}"
@@ -104,10 +100,6 @@ def test_tool_generation_with_full_schema(sample_app):
 
     # Check all tools have the appropriate schema information
     for tool in tools:
-        # Skip MCP's internal tool that doesn't follow the same patterns
-        if tool.name == "handle_mcp_connection_mcp_get":
-            continue
-
         description = tool.description
         # Check that the tool includes information about the Item schema
         assert "Item" in description, f"Item schema should be included in the description for {tool.name}"
@@ -126,10 +118,6 @@ def test_tool_generation_with_all_responses(sample_app):
 
     # Check all API tools include all response status codes
     for tool in tools:
-        # Skip MCP's internal tool that doesn't follow the same patterns
-        if tool.name == "handle_mcp_connection_mcp_get":
-            continue
-
         assert "200" in tool.description, f"Expected success response code in description for {tool.name}"
         assert "422" in tool.description, f"Expected 422 response code in description for {tool.name}"
 
@@ -150,10 +138,6 @@ def test_tool_generation_with_all_responses_and_full_schema(sample_app):
 
     # Check all tools include all response status codes and the full output schema
     for tool in tools:
-        # Skip MCP's internal tool that doesn't follow the same patterns
-        if tool.name == "handle_mcp_connection_mcp_get":
-            continue
-
         assert "200" in tool.description, f"Expected success response code in description for {tool.name}"
         assert "422" in tool.description, f"Expected 422 response code in description for {tool.name}"
         assert "Output Schema" in tool.description, f"Expected output schema in description for {tool.name}"

--- a/uv.lock
+++ b/uv.lock
@@ -207,7 +207,7 @@ wheels = [
 
 [[package]]
 name = "fastapi-mcp"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Describe your changes
When creating tools from openapi_schema, skip the internal handle_mcp_connection_mcp_get

## Issue ticket number and link (if applicable)
https://github.com/tadata-org/fastapi_mcp/issues/23

## Screenshots of the feature / bugfix
Before:
![image](https://github.com/user-attachments/assets/0118ace4-642a-403f-9ddb-dd7ce9367451)

After:
![image](https://github.com/user-attachments/assets/36cfb03e-2439-45e3-8d34-cd58b390b42e)

## Checklist before requesting a review
- [ ] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass
