### PR TITLE
limit tool name length

### DIFF
--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -43,13 +43,13 @@ def convert_openapi_to_mcp_tools(
         for method, operation in path_item.items():
             # Skip non-HTTP methods
             if method not in ["get", "post", "put", "delete", "patch"]:
-                logger.warning(f"Skipping non-HTTP method: {method}")
+                logger.warning(f"Skipping non-HTTP method: {method.upper()} {path}")
                 continue
 
             # Get operation metadata
             operation_id = operation.get("operationId")
             if not operation_id:
-                logger.warning(f"Skipping operation with no operationId: {operation}")
+                logger.warning(f"Skipping operation with no operationId: {method.upper()} {path}, details: {operation}")
                 continue
 
             # Save operation details for later HTTP calls

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -16,6 +16,8 @@ from logging import getLogger
 
 logger = getLogger(__name__)
 
+FULL_TOOL_NAME_MAX_LENGTH = 55
+
 
 class FastApiMCP:
     def __init__(
@@ -327,12 +329,33 @@ class FastApiMCP:
         operations_by_tag: Dict[str, List[str]] = {}
         for path, path_item in openapi_schema.get("paths", {}).items():
             for method, operation in path_item.items():
+                operation_id = operation.get("operationId")
                 if method not in ["get", "post", "put", "delete", "patch"]:
+                    logger.warning(f"Skipping non-HTTP method: {method.upper()} {path}, operation_id: {operation_id}")
                     continue
 
-                operation_id = operation.get("operationId")
                 if not operation_id:
+                    logger.warning(
+                        f"Skipping operation with no operationId: {method.upper()} {path}, details: {operation}"
+                    )
                     continue
+
+                operation_full_name = self.get_tool_full_name(operation_id)
+                if len(operation_full_name) > FULL_TOOL_NAME_MAX_LENGTH:
+                    logger.warning(f"Skipping operation with exceedingly long operationId: {operation_full_name}")
+                    continue
+
+                """
+                if method not in ["get", "post", "put", "delete", "patch"]:
+                logger.warning(f"Skipping non-HTTP method: {method.upper()} {path}")
+                continue
+
+            # Get operation metadata
+            operation_id = operation.get("operationId")
+            if not operation_id:
+                logger.warning(f"Skipping operation with no operationId: {method.upper()} {path}, details: {operation}")
+                continue
+                """
 
                 tags = operation.get("tags", [])
                 for tag in tags:
@@ -368,3 +391,6 @@ class FastApiMCP:
             }
 
         return filtered_tools
+
+    def get_tool_full_name(self, operation_id: str) -> str:
+        return f"{self.name}\\{operation_id}"


### PR DESCRIPTION
## Describe your changes
Resolves tadata-org/fastapi_mcp#64

Attempts to filter tools whose operation_id + server name are too long.

Note: The codebase seems to have logic overlap between the functions `server.py/_filter_tools` and `convert.py/def convert_openapi_to_mcp_tools` - I didn't want to rock the boat too much on my first attempted contribution, but I would be happy to try my luck at refactoring (perhaps in a separate ticket).

## Issue ticket number and link (if applicable)
https://github.com/tadata-org/fastapi_mcp/issues/64

## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [V] Added relevant tests
- [V] Run ruff & mypy
- [V] All tests pass
