### PR TITLE
fix: make sure items etc. is passed to mcp tools 

### DIFF
--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -202,11 +202,13 @@ def convert_openapi_to_mcp_tools(
                 param_desc = param.get("description", "")
                 param_required = param.get("required", True)  # Path params are usually required
 
-                properties[param_name] = {
-                    "type": param_schema.get("type", "string"),
-                    "title": param_name,
-                    "description": param_desc,
-                }
+                properties[param_name] = param_schema.copy()
+                properties[param_name]["title"] = param_name
+                if param_desc:
+                    properties[param_name]["description"] = param_desc
+
+                if "type" not in properties[param_name]:
+                    properties[param_name]["type"] = param_schema.get("type", "string")
 
                 if param_required:
                     required_props.append(param_name)
@@ -217,11 +219,14 @@ def convert_openapi_to_mcp_tools(
                 param_desc = param.get("description", "")
                 param_required = param.get("required", False)
 
-                properties[param_name] = {
-                    "type": get_single_param_type_from_schema(param_schema),
-                    "title": param_name,
-                    "description": param_desc,
-                }
+                properties[param_name] = param_schema.copy()
+                properties[param_name]["title"] = param_name
+                if param_desc:
+                    properties[param_name]["description"] = param_desc
+
+                if "type" not in properties[param_name]:
+                    properties[param_name]["type"] = get_single_param_type_from_schema(param_schema)
+
                 if "default" in param_schema:
                     properties[param_name]["default"] = param_schema["default"]
 
@@ -233,10 +238,14 @@ def convert_openapi_to_mcp_tools(
                 param_schema = param.get("schema", {})
                 param_required = param.get("required", False)
 
-                properties[param_name] = {
-                    "type": get_single_param_type_from_schema(param_schema),
-                    "title": param_name,
-                }
+                properties[param_name] = param_schema.copy()
+                properties[param_name]["title"] = param_name
+                if param_desc:
+                    properties[param_name]["description"] = param_desc
+
+                if "type" not in properties[param_name]:
+                    properties[param_name]["type"] = get_single_param_type_from_schema(param_schema)
+
                 if "default" in param_schema:
                     properties[param_name]["default"] = param_schema["default"]
 


### PR DESCRIPTION
## Describe your changes
This patch fixes a bug in `convert_openapi_to_mcp_tools` where array‑typed parameters lost their items sub‑schema and caused downstream function‑calling errors.

- Deep‑copy each parameter’s full schema instead of rebuilding only its type
- Preserve items, format, enum, default, etc., for all path, query, and body parameters
- No change to overall behaviour, tool definitions, HTTP mapping, and response docs remain the same

All existing tests still pass with same coverage.


## Issue
OpenAI, Gemini and other providers expects 'items' in array schema in tools to be defined.
When converting these where removed from the OpenAPI schema leading to the below error.

I got this error in both Cursor and using PydanticAI.

```bash
pydantic_ai.exceptions.ModelHTTPError: status_code: 400, model_name: gpt-4.1-mini, body: {'message': "Invalid schema for function 'update_tags': In context=('properties', 'tags'), array schema missing items.", 'type': 'invalid_request_error', 'param': 'tools[3].function.parameters', 'code': 'invalid_function_parameters'}
```

## Checklist before requesting a review
- [ ] Added relevant tests
- [X] Run ruff & mypy
- [X] All tests pass
```python
========================================================================= tests coverage ==========================================================================
_________________________________________________________ coverage: platform linux, python 3.12.2-final-0 _________________________________________________________

Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
fastapi_mcp/__init__.py                 5      0   100%
fastapi_mcp/openapi/__init__.py         0      0   100%
fastapi_mcp/openapi/convert.py        151     14    91%   46-47, 52-53, 116-119, 122, 126-128, 211, 234
fastapi_mcp/openapi/utils.py           79      5    94%   15, 143, 145, 147, 161
fastapi_mcp/server.py                 165     19    88%   167-170, 198, 222, 234, 242, 248-251, 267, 278-279, 302-305, 330, 334
fastapi_mcp/transport/__init__.py       0      0   100%
fastapi_mcp/transport/sse.py           59      0   100%
fastapi_mcp/types.py                    0      0   100%
fastapi_mcp/utils/__init__.py           0      0   100%
-----------------------------------------------------------------
TOTAL                                 459     38    92%
Coverage XML written to file coverage.xml
Required test coverage of 80% reached. Total coverage: 91.72%
======================================================================= 67 passed in 14.82s =======================================================================
```