### PR TITLE
Fix error in openapi conversion

### DIFF
--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -236,6 +236,7 @@ def convert_openapi_to_mcp_tools(
             # Add body parameters to properties
             for param_name, param in body_params:
                 param_schema = param.get("schema", {})
+                param_desc = param.get("description", "")
                 param_required = param.get("required", False)
 
                 properties[param_name] = param_schema.copy()


### PR DESCRIPTION
Fixes: UnboundLocalError: cannot access local variable 'param_desc' where it is not associated with a value.

This is happening after https://github.com/tadata-org/fastapi_mcp/commit/4ad4eef513b74892ff38502d958963aa56840120 because param_desc is read without being defined.

## Describe your changes

## Issue ticket number and link (if applicable)

## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [ ] Added relevant tests
- [ ] Run ruff & mypy
- [ ] All tests pass
