### PR TITLE
Fix/remove indent in server result (issue 114)

### DIFF
--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -422,7 +422,7 @@ class FastApiMCP:
             # TODO: Better typing for the AsyncClientProtocol. It should return a ResponseProtocol that has a json() method that returns a dict/list/etc.
             try:
                 result = response.json()
-                result_text = json.dumps(result, indent=2, ensure_ascii=False)
+                result_text = json.dumps(result, indent=None, ensure_ascii=False)
             except json.JSONDecodeError:
                 if hasattr(response, "text"):
                     result_text = response.text

--- a/tests/test_mcp_execute_api_tool.py
+++ b/tests/test_mcp_execute_api_tool.py
@@ -37,7 +37,7 @@ async def test_execute_api_tool_success(simple_fastapi_app: FastAPI):
     # Verify the result
     assert len(result) == 1
     assert isinstance(result[0], TextContent)
-    assert result[0].text == '{\n  "id": 1,\n  "name": "Test Item"\n}'
+    assert result[0].text == '{"id": 1, "name": "Test Item"}'
     
     # Verify the HTTP client was called correctly
     mock_client.get.assert_called_once_with(


### PR DESCRIPTION
## Describe your changes
remove indentation in server results

## Issue ticket number and link (if applicable)
https://github.com/tadata-org/fastapi_mcp/issues/114

## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [ ] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass
