### PR TITLE
Fix @modelcontextprotocol/inspector command-line

### DIFF
--- a/docs/getting-started/FAQ.mdx
+++ b/docs/getting-started/FAQ.mdx
@@ -31,7 +31,7 @@ To verify your FastApiMCP server is working properly, you can use the MCP Inspec
 1. Start your FastAPI application
 2. Open a new terminal and run the MCP Inspector:
    ```bash
-   npx @modelcontextprotocol/inspector node build/index.js
+   npx @modelcontextprotocol/inspector
    ```
 3. Connect to your MCP server by entering the mount path URL (default: `http://127.0.0.1:8000/mcp`)
 4. Navigate to the `Tools` section and click `List Tools` to see all available endpoints


### PR DESCRIPTION
## Describe your changes

This `node build/index.js` is needed only if your server is using Node and is ran with `./build/index.js`. It does not make sense to specify this with a Python server.

## Issue ticket number and link (if applicable)

Not applicable.

## Screenshots of the feature / bugfix

Not applicable.

## Checklist before requesting a review
- [ ] Added relevant tests
- [ ] Run ruff & mypy
- [ ] All tests pass

Not applicable.
