### PR TITLE
feat: Allow setting Authorization header from tool arguments

### DIFF
--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -413,6 +413,13 @@ class FastApiMCP:
             elif "authorization" in http_request_info.headers:
                 headers["Authorization"] = http_request_info.headers["authorization"]
 
+        # NEW: Check arguments for a user_access_token if Authorization header is still missing
+        if "Authorization" not in headers and arguments and "user_access_token" in arguments:
+            token = arguments.pop("user_access_token", None)  # Remove it from arguments so it doesn't become body
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+                logger.debug("Set Authorization header from 'user_access_token' in tool arguments.")
+
         body = arguments if arguments else None
 
         try:

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -375,6 +375,8 @@ class FastApiMCP:
         Returns:
             The result as MCP content types
         """
+        logger.debug(f"FastAPI-MCP: Received call_tool request. Tool: {tool_name}, Arguments: {json.dumps(arguments)}")
+
         if tool_name not in operation_map:
             raise Exception(f"Unknown tool: {tool_name}")
 


### PR DESCRIPTION
**Closes #143**

**Description:**

This PR enhances the `_execute_api_tool` method in `fastapi_mcp/server.py` to provide more flexibility for authenticating internal tool calls.

**Problem:**
Currently, `_execute_api_tool` primarily looks for an `Authorization` header in `http_request_info.headers`. This works well for external clients. However, for internal MCP clients (e.g., a backend service calling a tool via `MCPClientSession`), it's often more convenient to pass authentication tokens through the `arguments` of the `call_tool` request rather than reconstructing HTTP headers. If the token is passed only in the arguments, the tool execution would fail if the tool endpoint is protected.

**Solution:**
This change modifies `_execute_api_tool` to check the `arguments` dictionary for a `user_access_token` key if an `Authorization` header is not already present in `http_request_info.headers` or already set.

If `user_access_token` is found in the `arguments`:
1.  Its value is used to construct a `Bearer` token.
2.  This `Bearer` token is set as the `Authorization` header for the `httpx.AsyncClient` request made to the tool's endpoint.
3.  The `user_access_token` is removed from the `arguments` dictionary to prevent it from being unintentionally passed in the request body.

This approach maintains the priority of an explicitly passed `Authorization` header if one exists. It makes `fastapi-mcp` more adaptable for internal tool usage patterns where passing authentication details via arguments is preferred.

**Changes:**
*   Modified `fastapi_mcp/server.py` to include logic for extracting `user_access_token` from tool arguments and setting the `Authorization` header.
