### PR TITLE
docs(readme): Fix typo 'Additionaly' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ That's it! Your auto-generated MCP server is now available at `https://app.base.
 
 ## Documentation, Examples and Advanced Usage
 
-FastAPI-MCP provides [comprehensive documentation](https://fastapi-mcp.tadata.com/). Additionaly, check out the [examples directory](examples) for code samples demonstrating these features in action.
+FastAPI-MCP provides [comprehensive documentation](https://fastapi-mcp.tadata.com/). Additionally, check out the [examples directory](examples) for code samples demonstrating these features in action.
 
 ## FastAPI-first Approach
 


### PR DESCRIPTION
Corrects the misspelling of 'Additionaly' to 'Additionally' in the documentation section of the README.md file.

## Describe your changes
This pull request addresses a minor spelling error in the `README.md` file.
The word "Additionaly" in the "Documentation, Examples and Advanced Usage" section has been corrected to "Additionally" for improved readability and accuracy.
No functional changes are introduced by this commit.

## Issue ticket number and link (if applicable)
N/A

## Screenshots of the feature / bugfix
N/A

## Checklist before requesting a review
- [ ] Added relevant tests
- [ ] Run ruff & mypy
- [x] All tests pass
