### PR TITLE
Fix root_path duplication in MCP SSE messages endpoint

### DIFF
--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -335,7 +335,9 @@ class FastApiMCP:
         else:
             raise ValueError(f"Invalid router type: {type(router)}")
 
-        messages_path = f"{base_path}{mount_path}/messages/"
+        # For the SSE transport messages_path, we should not include the base_path
+        # because FastAPI will automatically prepend the root_path when serving the endpoint
+        messages_path = f"{mount_path}/messages/"
 
         sse_transport = FastApiSseTransport(messages_path)
 


### PR DESCRIPTION
Fixes root_path duplication issue where MCP endpoints showed /api/v1/api/v1/mcp/messages/ instead of /api/v1/mcp/messages/ when FastAPI apps use root_path. The fix removes base_path from messages_path construction since FastAPI automatically prepends root_path when serving endpoints.