### PR TITLE
fix: allow for self-referencing pydantic schema

### DIFF
--- a/tests/fixtures/types.py
+++ b/tests/fixtures/types.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional, List, Dict, Any
 from datetime import datetime, date
 from enum import Enum
@@ -95,6 +96,7 @@ class Product(BaseModel):
     updated_at: Optional[datetime] = None
     is_available: bool = True
     metadata: Dict[str, Any] = {}
+    related_products: Optional[List[Product]] = None
 
 
 class OrderItem(BaseModel):


### PR DESCRIPTION
## Describe your changes
This PR introduces a new field `related_products` in the `Products` fixture which replicates the failure case mentioned in #155 and makes existing tests fail with a `RecursionError` as expected. Then we add a new `seen` set to the function `resolve_schema_references` which resolves the error and makes the tests pass again.

## Issue ticket number and link (if applicable)
Fixes https://github.com/tadata-org/fastapi_mcp/issues/155 

## Checklist before requesting a review
- [x] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass
