### PR TITLE
feat: add HEAD router for mcp's mount_path

### DIFF
--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -3,7 +3,7 @@ import httpx
 from typing import Dict, Optional, Any, List, Union, Callable, Awaitable, Iterable, Literal, Sequence
 from typing_extensions import Annotated, Doc
 
-from fastapi import FastAPI, Request, APIRouter, params
+from fastapi import FastAPI, Request, Response, APIRouter, params
 from fastapi.openapi.utils import get_openapi
 from mcp.server.lowlevel.server import Server
 import mcp.types as types
@@ -194,6 +194,10 @@ class FastApiMCP:
         mount_path: str,
         dependencies: Optional[Sequence[params.Depends]],
     ):
+        @router.head(mount_path, include_in_schema=False, operation_id="mcp_connection", dependencies=dependencies)
+        async def handle_mcp_connection_head():
+            return Response(status_code=200)
+
         @router.get(mount_path, include_in_schema=False, operation_id="mcp_connection", dependencies=dependencies)
         async def handle_mcp_connection(request: Request):
             async with transport.connect_sse(request.scope, request.receive, request._send) as (reader, writer):


### PR DESCRIPTION
## Describe your changes

some framework(such as [langflow](https://github.com/langflow-ai/langflow)) will send a HEAD request to mount path to verify whether mcp service is available. So I add `@router.head(mount_path, ..)` that only return a empty 200 Response on `_register_mcp_connection_endpoint_sse`.

## Checklist before requesting a review
- [ ] Added relevant tests
- [x] Run ruff & mypy
- [ ] All tests pass
