### PR TITLE
feat: Avoid escaping non-ASCII characters when using json.dumps()

### DIFF
--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -124,14 +124,14 @@ def convert_openapi_to_mcp_tools(
                                 # If we have an example response, add it to the docs
                                 if example_response:
                                     response_info += "\n\n**Example Response:**\n```json\n"
-                                    response_info += json.dumps(example_response, indent=2)
+                                    response_info += json.dumps(example_response, indent=2, ensure_ascii=False)
                                     response_info += "\n```"
                                 # Otherwise generate an example from the schema
                                 else:
                                     generated_example = generate_example_from_schema(display_schema)
                                     if generated_example:
                                         response_info += "\n\n**Example Response:**\n```json\n"
-                                        response_info += json.dumps(generated_example, indent=2)
+                                        response_info += json.dumps(generated_example, indent=2, ensure_ascii=False)
                                         response_info += "\n```"
 
                                 # Only include full schema information if requested
@@ -141,15 +141,15 @@ def convert_openapi_to_mcp_tools(
                                         items_schema = display_schema["items"]
 
                                         response_info += "\n\n**Output Schema:** Array of items with the following structure:\n```json\n"
-                                        response_info += json.dumps(items_schema, indent=2)
+                                        response_info += json.dumps(items_schema, indent=2, ensure_ascii=False)
                                         response_info += "\n```"
                                     elif "properties" in display_schema:
                                         response_info += "\n\n**Output Schema:**\n```json\n"
-                                        response_info += json.dumps(display_schema, indent=2)
+                                        response_info += json.dumps(display_schema, indent=2, ensure_ascii=False)
                                         response_info += "\n```"
                                     else:
                                         response_info += "\n\n**Output Schema:**\n```json\n"
-                                        response_info += json.dumps(display_schema, indent=2)
+                                        response_info += json.dumps(display_schema, indent=2, ensure_ascii=False)
                                         response_info += "\n```"
 
                 tool_description += response_info


### PR DESCRIPTION
## Describe your changes
 Avoid escaping non-ASCII characters when using json.dumps()
```python
print(json.dumps({'你23实际': '世界速度'})) # output: {"\u4f6023\u5f00\u53d1": "\u4e16\u754c\u957f\u5ea6"}
print(json.dumps({'你23实际': '世界速度'}, ensure_ascii=False)) # output: {"你23实际": "世界速度"}
```

## Issue ticket number and link (if applicable)

## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [x] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass