### PR TITLE
Fix a bug with handling FastAPI `root_path` parameter

### DIFF
--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -299,7 +299,9 @@ class FastApiMCP:
             str,
             Doc(
                 """
-                Path where the MCP server will be mounted. Defaults to '/mcp'.
+                Path where the MCP server will be mounted.
+                Mount path is appended to the root path of FastAPI router, or to the prefix of APIRouter.
+                Defaults to '/mcp'.
                 """
             ),
         ] = "/mcp",
@@ -328,14 +330,9 @@ class FastApiMCP:
             router = self.fastapi
 
         # Build the base path correctly for the SSE transport
-        if isinstance(router, FastAPI):
-            base_path = router.root_path
-        elif isinstance(router, APIRouter):
-            base_path = self.fastapi.root_path + router.prefix
-        else:
-            raise ValueError(f"Invalid router type: {type(router)}")
-
-        messages_path = f"{base_path}{mount_path}/messages/"
+        assert isinstance(router, (FastAPI, APIRouter)), f"Invalid router type: {type(router)}"
+        base_path = mount_path if isinstance(router, FastAPI) else router.prefix + mount_path
+        messages_path = f"{base_path}/messages/"
 
         sse_transport = FastApiSseTransport(messages_path)
 

--- a/tests/fixtures/complex_app.py
+++ b/tests/fixtures/complex_app.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from fastapi import FastAPI, Query, Path, Body, Header, Cookie
 import pytest
 
+from tests.fixtures.conftest import make_fastapi_app_base
+
 from .types import (
     Product,
     Customer,
@@ -19,12 +21,9 @@ def make_complex_fastapi_app(
     example_product: Product,
     example_customer: Customer,
     example_order_response: OrderResponse,
+    parametrized_config: dict[str, Any] | None = None,
 ) -> FastAPI:
-    app = FastAPI(
-        title="Complex E-Commerce API",
-        description="A more complex API with nested models and various schemas",
-        version="1.0.0",
-    )
+    app = make_fastapi_app_base(parametrized_config=parametrized_config)
 
     @app.get(
         "/products",

--- a/tests/fixtures/conftest.py
+++ b/tests/fixtures/conftest.py
@@ -1,0 +1,12 @@
+from typing import Any
+from fastapi import FastAPI
+
+
+def make_fastapi_app_base(parametrized_config: dict[str, Any] | None = None) -> FastAPI:
+    fastapi_config: dict[str, Any] = {
+        "title": "Test API",
+        "description": "A test API app for unit testing",
+        "version": "0.1.0",
+    }
+    app = FastAPI(**fastapi_config | parametrized_config if parametrized_config is not None else {})
+    return app

--- a/tests/fixtures/simple_app.py
+++ b/tests/fixtures/simple_app.py
@@ -1,18 +1,15 @@
-from typing import Optional, List
+from typing import Optional, List, Any
 
 from fastapi import FastAPI, Query, Path, Body, HTTPException
 import pytest
 
+from tests.fixtures.conftest import make_fastapi_app_base
+
 from .types import Item
 
 
-def make_simple_fastapi_app() -> FastAPI:
-    app = FastAPI(
-        title="Test API",
-        description="A test API app for unit testing",
-        version="0.1.0",
-    )
-
+def make_simple_fastapi_app(parametrized_config: dict[str, Any] | None = None) -> FastAPI:
+    app = make_fastapi_app_base(parametrized_config=parametrized_config)
     items = [
         Item(id=1, name="Item 1", price=10.0, tags=["tag1", "tag2"], description="Item 1 description"),
         Item(id=2, name="Item 2", price=20.0, tags=["tag2", "tag3"]),
@@ -70,3 +67,8 @@ def make_simple_fastapi_app() -> FastAPI:
 @pytest.fixture
 def simple_fastapi_app() -> FastAPI:
     return make_simple_fastapi_app()
+
+
+@pytest.fixture
+def simple_fastapi_app_with_root_path() -> FastAPI:
+    return make_simple_fastapi_app(parametrized_config={"root_path": "/api/v1"})

--- a/tests/test_sse_real_transport.py
+++ b/tests/test_sse_real_transport.py
@@ -9,6 +9,7 @@ import sys
 import threading
 import coverage
 from typing import AsyncGenerator, Generator
+from fastapi import FastAPI
 from mcp.client.session import ClientSession
 from mcp.client.sse import sse_client
 from mcp import InitializeResult
@@ -18,26 +19,12 @@ import httpx
 import uvicorn
 from fastapi_mcp import FastApiMCP
 
-from .fixtures.simple_app import make_simple_fastapi_app
-
 
 HOST = "127.0.0.1"
 SERVER_NAME = "Test MCP Server"
 
 
-@pytest.fixture
-def server_port() -> int:
-    with socket.socket() as s:
-        s.bind((HOST, 0))
-        return s.getsockname()[1]
-
-
-@pytest.fixture
-def server_url(server_port: int) -> str:
-    return f"http://{HOST}:{server_port}"
-
-
-def run_server(server_port: int) -> None:
+def run_server(server_port: int, fastapi_app: FastAPI) -> None:
     # Initialize coverage for subprocesses
     cov = None
     if "COVERAGE_PROCESS_START" in os.environ:
@@ -72,16 +59,15 @@ def run_server(server_port: int) -> None:
         save_thread.start()
 
     # Configure the server
-    fastapi = make_simple_fastapi_app()
     mcp = FastApiMCP(
-        fastapi,
+        fastapi_app,
         name=SERVER_NAME,
         description="Test description",
     )
     mcp.mount()
 
     # Start the server
-    server = uvicorn.Server(config=uvicorn.Config(app=fastapi, host=HOST, port=server_port, log_level="error"))
+    server = uvicorn.Server(config=uvicorn.Config(app=fastapi_app, host=HOST, port=server_port, log_level="error"))
     server.run()
 
     # Give server time to start
@@ -94,13 +80,24 @@ def run_server(server_port: int) -> None:
         cov.save()
 
 
-@pytest.fixture()
-def server(server_port: int) -> Generator[None, None, None]:
+@pytest.fixture(params=["simple_fastapi_app", "simple_fastapi_app_with_root_path"])
+def server(request: pytest.FixtureRequest) -> Generator[str, None, None]:
     # Ensure COVERAGE_PROCESS_START is set in the environment for subprocesses
     coverage_rc = os.path.abspath(".coveragerc")
     os.environ["COVERAGE_PROCESS_START"] = coverage_rc
 
-    proc = multiprocessing.Process(target=run_server, kwargs={"server_port": server_port}, daemon=True)
+    # Get a free port
+    with socket.socket() as s:
+        s.bind((HOST, 0))
+        server_port = s.getsockname()[1]
+
+    # Run the server in a subprocess
+    fastapi_app = request.getfixturevalue(request.param)
+    proc = multiprocessing.Process(
+        target=run_server,
+        kwargs={"server_port": server_port, "fastapi_app": fastapi_app},
+        daemon=True,
+    )
     proc.start()
 
     # Wait for server to be running
@@ -117,7 +114,8 @@ def server(server_port: int) -> Generator[None, None, None]:
     else:
         raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
 
-    yield
+    # Return the server URL
+    yield f"http://{HOST}:{server_port}{fastapi_app.root_path}"
 
     # Signal the server to stop - added graceful shutdown before kill
     try:
@@ -134,8 +132,8 @@ def server(server_port: int) -> Generator[None, None, None]:
 
 
 @pytest.fixture()
-async def http_client(server: None, server_url: str) -> AsyncGenerator[httpx.AsyncClient, None]:
-    async with httpx.AsyncClient(base_url=server_url) as client:
+async def http_client(server: str) -> AsyncGenerator[httpx.AsyncClient, None]:
+    async with httpx.AsyncClient(base_url=server) as client:
         yield client
 
 
@@ -165,8 +163,8 @@ async def test_raw_sse_connection(http_client: httpx.AsyncClient) -> None:
 
 
 @pytest.mark.anyio
-async def test_sse_basic_connection(server: None, server_url: str) -> None:
-    async with sse_client(server_url + "/mcp") as streams:
+async def test_sse_basic_connection(server: str) -> None:
+    async with sse_client(server + "/mcp") as streams:
         async with ClientSession(*streams) as session:
             # Test initialization
             result = await session.initialize()
@@ -179,8 +177,8 @@ async def test_sse_basic_connection(server: None, server_url: str) -> None:
 
 
 @pytest.mark.anyio
-async def test_sse_tool_call(server: None, server_url: str) -> None:
-    async with sse_client(server_url + "/mcp") as streams:
+async def test_sse_tool_call(server: str) -> None:
+    async with sse_client(server + "/mcp") as streams:
         async with ClientSession(*streams) as session:
             await session.initialize()
 


### PR DESCRIPTION
## Describe your changes

#### Issue resolving
The current version of the library does not handle [FastAPI's `root_path`](https://fastapi.tiangolo.com/advanced/behind-a-proxy/?h=root_path#providing-the-root_path) parameter correctly.

`FastAPI.router` includes `root_path` in all its routes by default, so there is no need to add `root_path` to `/messages` again, as is done in the current version of `fastapi_mcp`. The problem is located [here](https://github.com/tadata-org/fastapi_mcp/blob/1ec91a8bb4ffd29b8d0dc8375179c1a3d84dd045/fastapi_mcp/server.py#L332).

Because of these duplicated `root_path` annotations, all requests to the `/messages` endpoints are processed incorrectly. This issue can be easily reproduced using the following snippet:
```python
from fastapi import FastAPI
from fastapi_mcp import FastApiMCP

app = FastAPI(root_path="/api")  # Does not work, but `app = FastAPI()` works
mcp = FastApiMCP(app)
mcp.mount()

if __name__ == "__main__":
    import uvicorn
    uvicorn.run(app, host="0.0.0.0", port=8101)
```

When you run MCP Inspector with `http://127.0.0.1:8101/mcp` connection string you will see the following log in the uvicorn output:
```
INFO:     Uvicorn running on http://0.0.0.0:8101 (Press CTRL+C to quit)
INFO:     127.0.0.1:53784 - "GET /mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:60936 - "GET /mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:60944 - "POST /api/api/mcp/messages/?session_id=a09e48d070204eb09420f54bdeb913ae HTTP/1.1" 404 Not Found
```

When you run MCP Inspector with `http://127.0.0.1:8101/api/mcp` connection string you will see the following log in the uvicorn output:
```
INFO:     Uvicorn running on http://0.0.0.0:8101 (Press CTRL+C to quit)
INFO:     127.0.0.1:32798 - "GET /mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:32800 - "GET /api/mcp HTTP/1.1" 200 OK
INFO:     127.0.0.1:32802 - "POST /api/api/mcp/messages/?session_id=d52c467095fc4350924b027fd3b578a2 HTTP/1.1" 404 Not Found
```

This PR fixes this issue.

#### Tests
This PR introduces some new test to prevent this issue in the future and also it refactors some basic fixtures to enhance flexibility by supporting multiple configurations for test servers.

I think there were a better way to add new tests for this `root_path` issue, but unfortunately I couldn't find an easy way to resolve a full URL to FastAPI's endpoint. If you can give me an advice how it could be enhanced - please do it and I'll prepare an update.

## Issue ticket number and link (if applicable)
N/A

## Screenshots of the feature / bugfix
FastAPI's `root_path` part duplication in the POST request to `messages` endpoint: 

![CleanShot 2025-06-08 at 01 40 01](https://github.com/user-attachments/assets/1325b289-84a6-452e-9219-2934a917ffb0)

An example of the broken unit tests, that were added in this PR in the case if we do not apply the main changes to `fastapi_mcp/server.py` (with the changes from this PR all tests are passed correctly).

![CleanShot 2025-06-08 at 01 41 01](https://github.com/user-attachments/assets/7bd86797-d402-44b8-8b8f-44c6ef2d6736)

With the changes from this PR all tests are passed correctly:

![CleanShot 2025-06-08 at 01 48 43](https://github.com/user-attachments/assets/fa19ba02-f641-4419-aaf7-bd3211a48afa)

## Checklist before requesting a review
- [x] Added relevant tests
- [x] Run ruff & mypy (No new errors, but current version of the repository has some errors)
- [x] All tests pass