### PR TITLE
docs: point out transport type

### DIFF
--- a/docs/getting-started/FAQ.mdx
+++ b/docs/getting-started/FAQ.mdx
@@ -33,7 +33,7 @@ To verify your FastApiMCP server is working properly, you can use the MCP Inspec
    ```bash
    npx @modelcontextprotocol/inspector
    ```
-3. Connect to your MCP server by entering the mount path URL (default: `http://127.0.0.1:8000/mcp`)
+3. Connect to your MCP server by selecting transport type "SSE" and entering the mount path URL (default: `http://127.0.0.1:8000/mcp`)
 4. Navigate to the `Tools` section and click `List Tools` to see all available endpoints
 5. Test an endpoint by:
    - Selecting a tool from the list


### PR DESCRIPTION
Point out user should select correct transport type (default STDIO won't work)

## Describe your changes

## Issue ticket number and link (if applicable)

## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [ ] Added relevant tests
- [ ] Run ruff & mypy
- [ ] All tests pass
