### PR TITLE
Enhance MCP client configuration documentation with IDE-specific examples and reference links

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -29,7 +29,7 @@ For more usage examples, see [Examples](https://github.com/tadata-org/fastapi_mc
 
 ## Running the server
 
-By running your FastAPI, your MCP will run at `https://app.base.url/mcp`. 
+By running your FastAPI, your MCP will run at `https://app.base.url/mcp`.
 
 For example, by using uvicorn, add to your code:
 ```python {9-11}
@@ -49,13 +49,30 @@ and run the server using `python fastapi_mcp_server.py`, which will serve you th
 
 ## Connecting a client to the MCP server
 
-Once your FastAPI app with MCP integration is running, you would want to connect it to an MCP client. 
+Once your FastAPI app with MCP integration is running, you would want to connect it to an MCP client.
 
 ### Connecting to the MCP Server using SSE
 
-For any MCP client supporting SSE, you will simply need to provide the MCP url.
+For any MCP client supporting SSE, you will simply need to provide the MCP url. Below are configuration examples for the most popular MCP clients:
 
-All the most popular MCP clients (Claude Desktop, Cursor & Windsurf) use the following config format:
+### Claude Desktop
+
+For more information, see [Anthropic's official documentation](https://docs.anthropic.com/en/docs/mcp).
+Claude Desktop uses the `url` parameter in its configuration. Example:
+
+```bash
+# Add the MCP server using the Claude CLI
+claude mcp add --transport sse fastapi-mcp http://localhost:8000/mcp
+
+# List all configured servers
+claude mcp list
+```
+
+
+### Cursor
+
+For more information, see [Cursor's official documentation](https://docs.cursor.com/context/model-context-protocol).
+Cursor uses the `url` parameter in its configuration. Example:
 
 ```json
 {
@@ -66,6 +83,23 @@ All the most popular MCP clients (Claude Desktop, Cursor & Windsurf) use the fol
   }
 }
 ```
+
+
+### Windsurf
+
+For more information, see [Windsurf's official documentation](https://docs.windsurf.com/windsurf/cascade/mcp).
+Windsurf uses the `serverUrl` parameter in its configuration. Example:
+
+```json
+{
+  "mcpServers": {
+    "fastapi-mcp": {
+      "serverUrl": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
 
 ### Connecting to the MCP Server using [mcp-remote](https://www.npmjs.com/package/mcp-remote)
 


### PR DESCRIPTION
# Add IDE-specific MCP configuration examples with documentation links

## Describe your changes

Enhanced the quickstart documentation to provide clear, IDE-specific MCP configuration instructions for all three major MCP clients:

1. **Claude Desktop**:
   - Added CLI-based configuration example using `claude mcp add` command
   - Included command to list configured servers
   - Highlighted that Claude Desktop uses the `url` parameter
   - Added link to Anthropic's official documentation

2. **Cursor**:
   - Maintained the JSON configuration example with the `url` parameter
   - Added clear section header for better organization
   - Added link to Cursor's official documentation

3. **Windsurf**:
   - Created a dedicated section for Windsurf configuration
   - Explicitly noted that Windsurf uses `serverUrl` instead of `url`
   - Added link to Windsurf's official documentation

These changes ensure that developers can correctly configure their MCP clients on the first attempt, regardless of which IDE they're using. The documentation now provides proper references to official documentation for each platform, allowing users to find more detailed information if needed.

## Issue ticket number and link (if applicable)

N/A - Documentation enhancement

## Screenshots of the feature / bugfix

Before:
```json
All the most popular MCP clients (Claude Desktop, Cursor & Windsurf) use the following config format:

{
  "mcpServers": {
    "fastapi-mcp": {
      "url": "http://localhost:8000/mcp"
    }
  }
}
```

After:
```json
{
  "mcpServers": {
    "fastapi-mcp": {
      "serverUrl": "http://localhost:8000/mcp"
    }
  }
}
```


## Checklist before requesting a review
- [x] Added relevant tests - N/A (Documentation only)
- [x] Run ruff & mypy - N/A (Documentation only)
- [x] All tests pass - N/A (Documentation only)