### PR TITLE
Fixes #123: allow usage of default_scope to be passed

### DIFF
--- a/fastapi_mcp/auth/proxy.py
+++ b/fastapi_mcp/auth/proxy.py
@@ -199,8 +199,10 @@ def setup_oauth_authorize_proxy(
         if not scope:
             logger.warning("Client didn't provide any scopes! Using default scopes.")
             scope = default_scope
+            logger.debug(f"Default scope: {scope}")
 
         scopes = scope.split()
+        logger.debug(f"Scopes passed: {scopes}")
         for required_scope in default_scope.split():
             if required_scope not in scopes:
                 scopes.append(required_scope)

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -264,6 +264,7 @@ class FastApiMCP:
                     client_id=self._auth_config.client_id,
                     authorize_url=self._auth_config.authorize_url,
                     audience=self._auth_config.audience,
+                    default_scope=self._auth_config.default_scope,
                 )
                 if self._auth_config.setup_fake_dynamic_registration:
                     assert self._auth_config.client_secret is not None


### PR DESCRIPTION
## Describe your changes
Fixes bug where default_scope is not being passed in.

Thanks to @ra-ver for the contents of this patch.

## Issue ticket number and link (if applicable)
#123 

## Screenshots of the feature / bugfix

```
INFO:     Uvicorn running on http://0.0.0.0:8000 (Press CTRL+C to quit)
WARNING:  2025-06-27 18:48:35   [fastapi_mcp.auth.proxy] Client didn't provide any scopes! Using default scopes.
INFO:     2025-06-27 18:48:35   [fastapi_mcp.auth.proxy] Default scope: myscope:read
INFO:     2025-06-27 18:48:35   [fastapi_mcp.auth.proxy] Scopes passed: ['myscope:read']
```

## Checklist before requesting a review
- [x] Added relevant tests
- [] Run ruff & mypy
- [x] All tests pass

====================================================== test session starts ======================================================
platform linux -- Python 3.12.10, pytest-8.3.5, pluggy-1.6.0 -- /usr/local/py-utils/venvs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /workspaces/adsk-secure-mfgdm-mcp-server/fastapi_mcp_upstream
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.9.0
collected 81 items                                                                                                              

tests/test_basic_functionality.py::test_create_mcp_server PASSED                                                          [  1%]
tests/test_basic_functionality.py::test_default_values PASSED                                                             [  2%]
tests/test_basic_functionality.py::test_normalize_paths PASSED                                                            [  3%]
tests/test_configuration.py::test_default_configuration PASSED                                                            [  4%]
tests/test_configuration.py::test_custom_configuration PASSED                                                             [  6%]
tests/test_configuration.py::test_describe_all_responses_config_simple_app PASSED                                         [  7%]
tests/test_configuration.py::test_describe_full_response_schema_config_simple_app PASSED                                  [  8%]
tests/test_configuration.py::test_describe_all_responses_and_full_response_schema_config_simple_app PASSED                [  9%]
tests/test_configuration.py::test_describe_all_responses_config_complex_app PASSED                                        [ 11%]
tests/test_configuration.py::test_describe_full_response_schema_config_complex_app PASSED                                 [ 12%]
tests/test_configuration.py::test_describe_all_responses_and_full_response_schema_config_complex_app PASSED               [ 13%]
tests/test_configuration.py::test_filtering_functionality PASSED                                                          [ 14%]
tests/test_configuration.py::test_filtering_edge_cases PASSED                                                             [ 16%]
tests/test_configuration.py::test_filtering_with_missing_operation_ids PASSED                                             [ 17%]
tests/test_configuration.py::test_filter_with_empty_tools PASSED                                                          [ 18%]
tests/test_configuration.py::test_filtering_with_empty_tags_array PASSED                                                  [ 19%]
tests/test_mcp_complex_app.py::test_list_tools SKIPPED (async def function and no async plugin installed (see warnings))  [ 20%]
tests/test_mcp_complex_app.py::test_call_tool_list_products_default SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 22%]
tests/test_mcp_complex_app.py::test_call_tool_list_products_with_filters SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 23%]
tests/test_mcp_complex_app.py::test_call_tool_get_product SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 24%]
tests/test_mcp_complex_app.py::test_call_tool_get_product_with_options SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 25%]
tests/test_mcp_complex_app.py::test_call_tool_create_order SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 27%]
tests/test_mcp_complex_app.py::test_call_tool_create_order_validation_error SKIPPED (async def function and no async
plugin installed (see warnings))                                                                                          [ 28%]
tests/test_mcp_complex_app.py::test_call_tool_get_customer SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 29%]
tests/test_mcp_complex_app.py::test_call_tool_get_customer_with_options SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 30%]
tests/test_mcp_complex_app.py::test_error_handling_missing_parameter SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 32%]
tests/test_mcp_execute_api_tool.py::test_execute_api_tool_success SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 33%]
tests/test_mcp_execute_api_tool.py::test_execute_api_tool_with_query_params SKIPPED (async def function and no async
plugin installed (see warnings))                                                                                          [ 34%]
tests/test_mcp_execute_api_tool.py::test_execute_api_tool_with_body SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 35%]
tests/test_mcp_execute_api_tool.py::test_execute_api_tool_with_non_ascii_chars SKIPPED (async def function and no async
plugin installed (see warnings))                                                                                          [ 37%]
tests/test_mcp_simple_app.py::test_list_tools SKIPPED (async def function and no async plugin installed (see warnings))   [ 38%]
tests/test_mcp_simple_app.py::test_call_tool_get_item_1 SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 39%]
tests/test_mcp_simple_app.py::test_call_tool_get_item_2 SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 40%]
tests/test_mcp_simple_app.py::test_call_tool_raise_error SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 41%]
tests/test_mcp_simple_app.py::test_error_handling SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 43%]
tests/test_mcp_simple_app.py::test_complex_tool_arguments SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 44%]
tests/test_mcp_simple_app.py::test_call_tool_list_items_default SKIPPED (async def function and no async plugin installed
(see warnings))                                                                                                           [ 45%]
tests/test_mcp_simple_app.py::test_call_tool_list_items_with_pagination SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 46%]
tests/test_mcp_simple_app.py::test_call_tool_get_item_not_found SKIPPED (async def function and no async plugin installed
(see warnings))                                                                                                           [ 48%]
tests/test_mcp_simple_app.py::test_call_tool_update_item SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 49%]
tests/test_mcp_simple_app.py::test_call_tool_delete_item SKIPPED (async def function and no async plugin installed (see
warnings))                                                                                                                [ 50%]
tests/test_mcp_simple_app.py::test_call_tool_get_item_with_details SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 51%]
tests/test_mcp_simple_app.py::test_headers_passthrough_to_tool_handler SKIPPED (async def function and no async plugin
installed (see warnings))                                                                                                 [ 53%]
tests/test_openapi_conversion.py::test_simple_app_conversion PASSED                                                       [ 54%]
tests/test_openapi_conversion.py::test_complex_app_conversion PASSED                                                      [ 55%]
tests/test_openapi_conversion.py::test_describe_full_response_schema PASSED                                               [ 56%]
tests/test_openapi_conversion.py::test_describe_all_responses PASSED                                                      [ 58%]
tests/test_openapi_conversion.py::test_schema_utils PASSED                                                                [ 59%]
tests/test_openapi_conversion.py::test_parameter_handling PASSED                                                          [ 60%]
tests/test_openapi_conversion.py::test_request_body_handling PASSED                                                       [ 61%]
tests/test_openapi_conversion.py::test_missing_type_handling PASSED                                                       [ 62%]
tests/test_openapi_conversion.py::test_body_params_descriptions_and_defaults PASSED                                       [ 64%]
tests/test_openapi_conversion.py::test_body_params_edge_cases PASSED                                                      [ 65%]
tests/test_sse_mock_transport.py::test_handle_post_message_missing_session_id[asyncio] PASSED                             [ 66%]
tests/test_sse_mock_transport.py::test_handle_post_message_invalid_session_id[asyncio] PASSED                             [ 67%]
tests/test_sse_mock_transport.py::test_handle_post_message_session_not_found[asyncio] PASSED                              [ 69%]
tests/test_sse_mock_transport.py::test_handle_post_message_validation_error[asyncio] PASSED                               [ 70%]
tests/test_sse_mock_transport.py::test_handle_post_message_general_exception[asyncio] PASSED                              [ 71%]
tests/test_sse_mock_transport.py::test_send_message_safely_with_validation_error[asyncio] PASSED                          [ 72%]
tests/test_sse_mock_transport.py::test_send_message_safely_with_jsonrpc_message[asyncio] PASSED                           [ 74%]
tests/test_sse_mock_transport.py::test_send_message_safely_exception_handling[asyncio] PASSED                             [ 75%]
tests/test_sse_mock_transport.py::test_handle_post_message_missing_session_id[trio] PASSED                                [ 76%]
tests/test_sse_mock_transport.py::test_handle_post_message_invalid_session_id[trio] PASSED                                [ 77%]
tests/test_sse_mock_transport.py::test_handle_post_message_session_not_found[trio] PASSED                                 [ 79%]
tests/test_sse_mock_transport.py::test_handle_post_message_validation_error[trio] PASSED                                  [ 80%]
tests/test_sse_mock_transport.py::test_handle_post_message_general_exception[trio] PASSED                                 [ 81%]
tests/test_sse_mock_transport.py::test_send_message_safely_with_validation_error[trio] PASSED                             [ 82%]
tests/test_sse_mock_transport.py::test_send_message_safely_with_jsonrpc_message[trio] PASSED                              [ 83%]
tests/test_sse_mock_transport.py::test_send_message_safely_exception_handling[trio] PASSED                                [ 85%]
tests/test_sse_real_transport.py::test_raw_sse_connection[asyncio] PASSED                                                 [ 86%]
tests/test_sse_real_transport.py::test_sse_basic_connection[asyncio] PASSED                                               [ 87%]
tests/test_sse_real_transport.py::test_sse_tool_call[asyncio] PASSED                                                      [ 88%]
tests/test_sse_real_transport.py::test_raw_sse_connection[trio] PASSED                                                    [ 90%]
tests/test_sse_real_transport.py::test_sse_basic_connection[trio] PASSED                                                  [ 91%]
tests/test_sse_real_transport.py::test_sse_tool_call[trio] PASSED                                                         [ 92%]
tests/test_types_validation.py::TestOAuthMetadata::test_non_empty_lists_validation PASSED                                 [ 93%]
tests/test_types_validation.py::TestOAuthMetadata::test_authorization_endpoint_required_for_authorization_code PASSED     [ 95%]
tests/test_types_validation.py::TestOAuthMetadata::test_model_dump_excludes_none PASSED                                   [ 96%]
tests/test_types_validation.py::TestAuthConfig::test_required_fields_validation PASSED                                    [ 97%]
tests/test_types_validation.py::TestAuthConfig::test_client_id_required_for_setup_proxies PASSED                          [ 98%]
tests/test_types_validation.py::TestAuthConfig::test_client_secret_required_for_fake_registration PASSED                  [100%
