### PR TITLE
Change fork method in SSE transport tests to avoid pickling issues

### DIFF
--- a/tests/test_sse_real_transport.py
+++ b/tests/test_sse_real_transport.py
@@ -91,9 +91,12 @@ def server(request: pytest.FixtureRequest) -> Generator[str, None, None]:
         s.bind((HOST, 0))
         server_port = s.getsockname()[1]
 
+    # Use fork method to avoid pickling issues
+    ctx = multiprocessing.get_context("fork")
+
     # Run the server in a subprocess
     fastapi_app = request.getfixturevalue(request.param)
-    proc = multiprocessing.Process(
+    proc = ctx.Process(
         target=run_server,
         kwargs={"server_port": server_port, "fastapi_app": fastapi_app},
         daemon=True,


### PR DESCRIPTION
## Describe your changes
- Fix unit test for PR: https://github.com/tadata-org/fastapi_mcp/pull/163:
  - Updated the server fixture to utilize the "fork" method for process creation, addressing pickling issues with multiprocessing.
  - Ensured compatibility with FastAPI app instances in test setups.
- Comment with the problem description is here: https://github.com/tadata-org/fastapi_mcp/pull/163#issuecomment-3055176997

## Issue ticket number and link (if applicable)
N/A

## Screenshots of the feature / bugfix
N/A

## Checklist before requesting a review
- [ ] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass
