### PR TITLE
Add streamable http support

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,3 @@
+# Repomix output
+!repomix-output.txt
+!repomix-output.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: v5.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: \.md$
+        exclude: \.(md|mdx)$
       - id: check-yaml
       - id: check-added-large-files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+🚀 **FastAPI-MCP now supports Streamable HTTP transport.**
+
+HTTP transport is now the recommended approach, following the specification that positions HTTP as the standard while maintaining SSE for backwards compatibility.
+
+### ⚠️ Breaking Changes
+- **`mount()` method is deprecated** and will be removed in a future version. Use `mount_http()` for HTTP transport (recommended) or `mount_sse()` for SSE transport.
+
+### Added
+- 🎉 **Streamable HTTP Transport Support** - New `mount_http()` method implementing the MCP Streamable HTTP specification
+- 🎉 **Stateful Session Management** - For both HTTP and SSE transports
+
 ## [0.3.7]
 
 ### Fixed

--- a/docs/advanced/asgi.mdx
+++ b/docs/advanced/asgi.mdx
@@ -1,0 +1,31 @@
+---
+title: Transport
+description: How to communicate with the FastAPI app
+icon: microchip
+---
+
+FastAPI-MCP uses ASGI transport by default, which means it communicates directly with your FastAPI app without making HTTP requests. This is more efficient and doesn't require a base URL.
+
+It's not even necessary that the FastAPI server will run.
+
+If you need to specify a custom base URL or use a different transport method, you can provide your own `httpx.AsyncClient`:
+
+```python {7-10, 14}
+import httpx
+from fastapi import FastAPI
+from fastapi_mcp import FastApiMCP
+
+app = FastAPI()
+
+custom_client = httpx.AsyncClient(
+    base_url="https://api.example.com",
+    timeout=30.0
+)
+
+mcp = FastApiMCP(
+    app,
+    http_client=custom_client
+)
+
+mcp.mount()
+```

--- a/docs/advanced/auth.mdx
+++ b/docs/advanced/auth.mdx
@@ -49,7 +49,7 @@ mcp = FastApiMCP(
         dependencies=[Depends(verify_auth)],
     ),
 )
-mcp.mount()
+mcp.mount_http()
 ```
 
 For a complete working example of authorization header, check out the [Token Passthrough Example](https://github.com/tadata-org/fastapi_mcp/blob/main/examples/08_auth_example_token_passthrough.py) in the examples folder.
@@ -79,7 +79,7 @@ mcp = FastApiMCP(
     ),
 )
 
-mcp.mount()
+mcp.mount_http()
 ```
 
 And you can call it like:
@@ -131,7 +131,7 @@ mcp = FastApiMCP(
     ),
 )
 
-mcp.mount()
+mcp.mount_http()
 ```
 
 This approach gives you complete control over the OAuth metadata and is useful when:
@@ -195,8 +195,8 @@ You also need to make sure to configure callback URLs properly in your OAuth pro
 Proxies solve several problems:
 
 1.  **Missing registration endpoints**:  
-    The MCP spec expects OAuth providers to support [dynamic client registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591), but many don't.  
-    Furthermore, dynamic client registration is probably overkill for most use cases.  
+    The MCP spec expects OAuth providers to support [dynamic client registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591), but many don't.
+    Furthermore, dynamic client registration is probably overkill for most use cases.
     The `setup_fake_dynamic_registration` option (True by default) creates a compatible endpoint that just returns a static client ID and secret.
 
 2.  **Scope handling**:  

--- a/docs/advanced/deploy.mdx
+++ b/docs/advanced/deploy.mdx
@@ -24,7 +24,7 @@ mcp_app = FastAPI()
 mcp = FastApiMCP(api_app)
 
 # Mount the MCP server to the separate app
-mcp.mount(mcp_app)
+mcp.mount_http(mcp_app)
 ```
 
 Then, you can run both apps separately:

--- a/docs/advanced/refresh.mdx
+++ b/docs/advanced/refresh.mdx
@@ -13,7 +13,7 @@ from fastapi_mcp import FastApiMCP
 app = FastAPI()
 
 mcp = FastApiMCP(app)
-mcp.mount()
+mcp.mount_http()
 
 # Add new endpoints after MCP server creation
 @app.get("/new/endpoint/", operation_id="new_endpoint")

--- a/docs/advanced/transport.mdx
+++ b/docs/advanced/transport.mdx
@@ -1,31 +1,91 @@
 ---
-title: Transport
-description: How to communicate with the FastAPI app
+title: MCP Transport
+description: Understanding MCP transport methods and how to choose between them
 icon: car
 ---
 
-FastAPI-MCP uses ASGI transport by default, which means it communicates directly with your FastAPI app without making HTTP requests. This is more efficient and doesn't require a base URL.
+FastAPI-MCP supports two MCP transport methods for client-server communication: **HTTP transport** (recommended) and **SSE transport** (backwards compatibility).
 
-It's not even necessary that the FastAPI server will run.
+## HTTP Transport (Recommended)
 
-If you need to specify a custom base URL or use a different transport method, you can provide your own `httpx.AsyncClient`:
+HTTP transport is the **recommended** transport method as it implements the latest MCP Streamable HTTP specification. It provides better session management, more robust connection handling, and aligns with standard HTTP practices.
 
-```python {7-10, 14}
-import httpx
+### Using HTTP Transport
+
+```python {7}
 from fastapi import FastAPI
 from fastapi_mcp import FastApiMCP
 
 app = FastAPI()
+mcp = FastApiMCP(app)
 
-custom_client = httpx.AsyncClient(
-    base_url="https://api.example.com",
-    timeout=30.0
-)
+# Mount using HTTP transport (recommended)
+mcp.mount_http()
+```
 
-mcp = FastApiMCP(
-    app,
-    http_client=custom_client
-)
+## SSE Transport (Backwards Compatibility)
 
-mcp.mount()
+SSE (Server-Sent Events) transport is maintained for backwards compatibility with older MCP implementations.
+
+### Using SSE Transport
+
+```python {7}
+from fastapi import FastAPI
+from fastapi_mcp import FastApiMCP
+
+app = FastAPI()
+mcp = FastApiMCP(app)
+
+# Mount using SSE transport (backwards compatibility)
+mcp.mount_sse()
+```
+
+## Advanced Configuration
+
+Both transport methods support the same FastAPI integration features like custom routing and authentication:
+
+```python
+from fastapi import FastAPI, APIRouter
+from fastapi_mcp import FastApiMCP
+
+app = FastAPI()
+router = APIRouter(prefix="/api/v1")
+
+mcp = FastApiMCP(app)
+
+# Mount to custom path with HTTP transport
+mcp.mount_http(router, mount_path="/my-http")
+
+# Or with SSE transport
+mcp.mount_sse(router, mount_path="/my-sse")
+```
+
+## Client Connection Examples
+
+### HTTP Transport Client Connection
+
+For HTTP transport, MCP clients connect directly to the HTTP endpoint:
+
+```json
+{
+  "mcpServers": {
+    "fastapi-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+### SSE Transport Client Connection
+
+For SSE transport, MCP clients use the same URL but communicate via Server-Sent Events:
+
+```json
+{
+  "mcpServers": {
+    "fastapi-mcp": {
+      "url": "http://localhost:8000/sse"
+    }
+  }
+}
 ```

--- a/docs/configurations/customization.mdx
+++ b/docs/configurations/customization.mdx
@@ -18,7 +18,7 @@ mcp = FastApiMCP(
     name="My API MCP",
     description="Very cool MCP server",
 )
-mcp.mount()
+mcp.mount_http()
 ```
 
 ## Tool and schema descriptions
@@ -39,7 +39,7 @@ mcp = FastApiMCP(
     describe_full_response_schema=True
 )
 
-mcp.mount()
+mcp.mount_http()
 ```
 
 ## Customizing Exposed Endpoints
@@ -66,7 +66,7 @@ The relevant arguments for these configurations are `include_operations`, `exclu
         app,
         include_operations=["get_user", "create_user"]
     )
-    mcp.mount()
+    mcp.mount_http()
     ```
 
     ```python Exclude Operations {8}
@@ -79,7 +79,7 @@ The relevant arguments for these configurations are `include_operations`, `exclu
         app,
         exclude_operations=["delete_user"]
     )
-    mcp.mount()
+    mcp.mount_http()
     ```
 
     ```python Include Tags {8}
@@ -92,7 +92,7 @@ The relevant arguments for these configurations are `include_operations`, `exclu
         app,
         include_tags=["users", "public"]
     )
-    mcp.mount()
+    mcp.mount_http()
     ```
 
     ```python Exclude Tags {8}
@@ -105,7 +105,7 @@ The relevant arguments for these configurations are `include_operations`, `exclu
         app,
         exclude_tags=["admin", "internal"]
     )
-    mcp.mount()
+    mcp.mount_http()
     ```
 
     ```python Combined (include mode) {8-9}
@@ -119,7 +119,7 @@ The relevant arguments for these configurations are `include_operations`, `exclu
         include_operations=["user_login"],
         include_tags=["public"]
     )
-    mcp.mount()
+    mcp.mount_http()
     ```
 </CodeGroup>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,86 +1,84 @@
 {
-    "$schema": "https://mintlify.com/docs.json",
-    "name": "FastAPI MCP",
-    "background": {
-        "color": {
-            "dark": "#222831",
-            "light": "#EEEEEE"
-        },
-        "decoration": "windows"
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "FastAPI MCP",
+  "background": {
+    "color": {
+      "dark": "#222831",
+      "light": "#EEEEEE"
     },
-    "colors": {
-      "primary": "#6d45dc",
-      "light": "#9f8ded",
-      "dark": "#6a42d7"
-    },
-    "description": "Convert your FastAPI app into a MCP server with zero configuration",
-    "favicon": "media/favicon.png",
-    "navigation": {
-      "groups": [
-        {
-            "group": "Getting Started",
-            "pages": [
-              "getting-started/welcome",
-              "getting-started/installation",
-              "getting-started/quickstart",
-              "getting-started/FAQ",
-              "getting-started/best-practices"
-            ]
-        },
-        {
-            "group": "Configurations",
-            "pages": [
-              "configurations/tool-naming",
-              "configurations/customization"
-            ]
-        },
-        {
-            "group": "Advanced Usage",
-            "pages": [
-              "advanced/auth",
-              "advanced/deploy",
-              "advanced/refresh",
-              "advanced/transport"
-            ]
-        }
-      ],
-      "global": {
-        "anchors": [
-          {
-            "anchor": "Documentation",
-            "href": "https://fastapi-mcp.tadata.com/",
-            "icon": "book-open-cover"
-          },
-          {
-            "anchor": "Community",
-            "href": "https://join.slack.com/t/themcparty/shared_invite/zt-30yxr1zdi-2FG~XjBA0xIgYSYuKe7~Xg",
-            "icon": "slack"
-          },
-          {
-            "anchor": "Blog",
-            "href": "https://medium.com/@miki_45906",
-            "icon": "newspaper"
-          }
+    "decoration": "windows"
+  },
+  "colors": {
+    "primary": "#6d45dc",
+    "light": "#9f8ded",
+    "dark": "#6a42d7"
+  },
+  "description": "Convert your FastAPI app into a MCP server with zero configuration",
+  "favicon": "media/favicon.png",
+  "navigation": {
+    "groups": [
+      {
+        "group": "Getting Started",
+        "pages": [
+          "getting-started/welcome",
+          "getting-started/installation",
+          "getting-started/quickstart",
+          "getting-started/FAQ",
+          "getting-started/best-practices"
+        ]
+      },
+      {
+        "group": "Configurations",
+        "pages": ["configurations/tool-naming", "configurations/customization"]
+      },
+      {
+        "group": "Advanced Usage",
+        "pages": [
+          "advanced/auth",
+          "advanced/deploy",
+          "advanced/refresh",
+          "advanced/asgi",
+          "advanced/transport"
         ]
       }
-    },
-    "logo": {
-      "light": "/media/dark_logo.png",
-      "dark": "/media/light_logo.png",
-      "href": "https://tadata.com/"
-    },
-    "navbar": {
-        "primary": {
-            "href": "https://github.com/tadata-org/fastapi_mcp",
-            "type": "github"
+    ],
+    "global": {
+      "anchors": [
+        {
+          "anchor": "Documentation",
+          "href": "https://fastapi-mcp.tadata.com/",
+          "icon": "book-open-cover"
+        },
+        {
+          "anchor": "Community",
+          "href": "https://join.slack.com/t/themcparty/shared_invite/zt-30yxr1zdi-2FG~XjBA0xIgYSYuKe7~Xg",
+          "icon": "slack"
+        },
+        {
+          "anchor": "Blog",
+          "href": "https://medium.com/@miki_45906",
+          "icon": "newspaper"
         }
-    },
-    "footer": {
-      "socials": {
-        "x": "https://x.com/makhlevich",
-        "github": "https://github.com/tadata-org/fastapi_mcp",
-        "website": "https://tadata.com/"
-      }
-    },
-    "theme": "mint"
-  }
+      ]
+    }
+  },
+  "logo": {
+    "light": "/media/dark_logo.png",
+    "dark": "/media/light_logo.png",
+    "href": "https://tadata.com/"
+  },
+  "navbar": {
+    "primary": {
+      "href": "https://github.com/tadata-org/fastapi_mcp",
+      "type": "github"
+    }
+  },
+  "footer": {
+    "socials": {
+      "x": "https://x.com/makhlevich",
+      "github": "https://github.com/tadata-org/fastapi_mcp",
+      "website": "https://tadata.com/"
+    }
+  },
+  "theme": "mint"
+}

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -22,14 +22,14 @@ app = FastAPI()
 mcp = FastApiMCP(app)
 
 # Mount the MCP server directly to your app
-mcp.mount()
+mcp.mount_http()
 ```
 
 For more usage examples, see [Examples](https://github.com/tadata-org/fastapi_mcp/tree/main/examples) section in the project.
 
 ## Running the server
 
-By running your FastAPI, your MCP will run at `https://app.base.url/mcp`. 
+By running your FastAPI, your MCP will run at `https://app.base.url/mcp`.
 
 For example, by using uvicorn, add to your code:
 ```python {9-11}
@@ -39,7 +39,7 @@ from fastapi_mcp import FastApiMCP
 app = FastAPI()
 
 mcp = FastApiMCP(app)
-mcp.mount()
+mcp.mount_http()
 
 if __name__ == "__main__":
     import uvicorn
@@ -49,7 +49,7 @@ and run the server using `python fastapi_mcp_server.py`, which will serve you th
 
 ## Connecting a client to the MCP server
 
-Once your FastAPI app with MCP integration is running, you would want to connect it to an MCP client. 
+Once your FastAPI app with MCP integration is running, you would want to connect it to an MCP client.
 
 ### Connecting to the MCP Server using SSE
 

--- a/docs/getting-started/welcome.mdx
+++ b/docs/getting-started/welcome.mdx
@@ -15,7 +15,7 @@ from fastapi_mcp import FastApiMCP
 app = FastAPI()
 
 mcp = FastApiMCP(app)
-mcp.mount()
+mcp.mount_http()
 ```
 That's it! Your auto-generated MCP server is now available at `https://app.base.url/mcp`
 
@@ -33,7 +33,7 @@ That's it! Your auto-generated MCP server is now available at `https://app.base.
 
 - [**Flexible deployment**](/advanced/deploy) - Mount your MCP server to the same app, or deploy separately
 
-- [**ASGI transport**](/advanced/transport) - Uses FastAPI's ASGI interface directly for efficient communication
+- [**ASGI interface**](/advanced/asgi) - Uses FastAPI's ASGI interface directly for efficient internal communication
 
 ## Hosted Solution
 

--- a/examples/01_basic_usage_example.py
+++ b/examples/01_basic_usage_example.py
@@ -1,4 +1,4 @@
-from examples.shared.apps.items import app # The FastAPI app
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 from fastapi_mcp import FastApiMCP
@@ -9,7 +9,7 @@ setup_logging()
 mcp = FastApiMCP(app)
 
 # Mount the MCP server to the FastAPI app
-mcp.mount()
+mcp.mount_http()
 
 
 if __name__ == "__main__":

--- a/examples/02_full_schema_description_example.py
+++ b/examples/02_full_schema_description_example.py
@@ -1,8 +1,8 @@
-
 """
 This example shows how to describe the full response schema instead of just a response example.
 """
-from examples.shared.apps.items import app # The FastAPI app
+
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 from fastapi_mcp import FastApiMCP
@@ -18,9 +18,9 @@ mcp = FastApiMCP(
     describe_all_responses=True,  # Describe all the possible responses instead of just the success (2XX) response
 )
 
-mcp.mount()
+mcp.mount_http()
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/03_custom_exposed_endpoints_example.py
+++ b/examples/03_custom_exposed_endpoints_example.py
@@ -6,7 +6,8 @@ Notes on filtering:
 - You can combine operation filtering with tag filtering (e.g., use `include_operations` with `include_tags`)
 - When combining filters, a greedy approach will be taken. Endpoints matching either criteria will be included
 """
-from examples.shared.apps.items import app # The FastAPI app
+
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 from fastapi_mcp import FastApiMCP
@@ -24,7 +25,7 @@ include_operations_mcp = FastApiMCP(
 
 # Filter by excluding specific operation IDs
 exclude_operations_mcp = FastApiMCP(
-    app,    
+    app,
     name="Item API MCP - Excluded Operations",
     exclude_operations=["create_item", "update_item", "delete_item"],
 )
@@ -52,11 +53,11 @@ combined_include_mcp = FastApiMCP(
 )
 
 # Mount all MCP servers with different paths
-include_operations_mcp.mount(mount_path="/include-operations-mcp")
-exclude_operations_mcp.mount(mount_path="/exclude-operations-mcp")
-include_tags_mcp.mount(mount_path="/include-tags-mcp")
-exclude_tags_mcp.mount(mount_path="/exclude-tags-mcp")
-combined_include_mcp.mount(mount_path="/combined-include-mcp")
+include_operations_mcp.mount_http(mount_path="/include-operations-mcp")
+exclude_operations_mcp.mount_http(mount_path="/exclude-operations-mcp")
+include_tags_mcp.mount_http(mount_path="/include-tags-mcp")
+exclude_tags_mcp.mount_http(mount_path="/exclude-tags-mcp")
+combined_include_mcp.mount_http(mount_path="/combined-include-mcp")
 
 if __name__ == "__main__":
     import uvicorn

--- a/examples/04_separate_server_example.py
+++ b/examples/04_separate_server_example.py
@@ -2,6 +2,7 @@
 This example shows how to run the MCP server and the FastAPI app separately.
 You can create an MCP server from one FastAPI app, and mount it to a different app.
 """
+
 from fastapi import FastAPI
 
 from examples.shared.apps.items import app
@@ -22,7 +23,7 @@ mcp = FastApiMCP(app)
 
 # Mount the MCP server to a separate FastAPI app
 mcp_app = FastAPI()
-mcp.mount(mcp_app)
+mcp.mount_http(mcp_app)
 
 # Run the MCP server separately from the original FastAPI app.
 # It still works 🚀

--- a/examples/05_reregister_tools_example.py
+++ b/examples/05_reregister_tools_example.py
@@ -1,15 +1,16 @@
 """
 This example shows how to re-register tools if you add endpoints after the MCP server was created.
 """
-from examples.shared.apps.items import app # The FastAPI app
+
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 from fastapi_mcp import FastApiMCP
 
 setup_logging()
 
-mcp = FastApiMCP(app) # Add MCP server to the FastAPI app
-mcp.mount() # MCP server
+mcp = FastApiMCP(app)  # Add MCP server to the FastAPI app
+mcp.mount_http()  # MCP server
 
 
 # This endpoint will not be registered as a tool, since it was added after the MCP instance was created
@@ -24,5 +25,5 @@ mcp.setup_server()
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/06_custom_mcp_router_example.py
+++ b/examples/06_custom_mcp_router_example.py
@@ -1,7 +1,8 @@
 """
 This example shows how to mount the MCP server to a specific APIRouter, giving a custom mount path.
 """
-from examples.shared.apps.items import app # The FastAPI app
+
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 from fastapi import APIRouter
@@ -9,17 +10,17 @@ from fastapi_mcp import FastApiMCP
 
 setup_logging()
 
-other_router = APIRouter(prefix="/other/route")    
+other_router = APIRouter(prefix="/other/route")
 app.include_router(other_router)
 
 mcp = FastApiMCP(app)
 
 # Mount the MCP server to a specific router.
 # It will now only be available at `/other/route/mcp`
-mcp.mount(other_router)
+mcp.mount_http(other_router)
 
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/07_configure_http_timeout_example.py
+++ b/examples/07_configure_http_timeout_example.py
@@ -2,7 +2,8 @@
 This example shows how to configure the HTTP client timeout for the MCP server.
 In case you have API endpoints that take longer than 5 seconds to respond, you can increase the timeout.
 """
-from examples.shared.apps.items import app # The FastAPI app
+
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 import httpx
@@ -12,14 +13,11 @@ from fastapi_mcp import FastApiMCP
 setup_logging()
 
 
-mcp = FastApiMCP(
-    app,
-    http_client=httpx.AsyncClient(timeout=20)
-)
-mcp.mount()
+mcp = FastApiMCP(app, http_client=httpx.AsyncClient(timeout=20))
+mcp.mount_http()
 
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/08_auth_example_token_passthrough.py
+++ b/examples/08_auth_example_token_passthrough.py
@@ -53,7 +53,6 @@ mcp = FastApiMCP(
 
 # Mount the MCP server
 mcp.mount_http()
-# mcp.mount_sse() # Or use SSE transport instead
 
 
 if __name__ == "__main__":

--- a/examples/08_auth_example_token_passthrough.py
+++ b/examples/08_auth_example_token_passthrough.py
@@ -21,7 +21,8 @@ In order to configure the auth header, the config file for the MCP server should
 }
 ```
 """
-from examples.shared.apps.items import app # The FastAPI app
+
+from examples.shared.apps.items import app  # The FastAPI app
 from examples.shared.setup import setup_logging
 
 from fastapi import Depends
@@ -34,10 +35,12 @@ setup_logging()
 # Scheme for the Authorization header
 token_auth_scheme = HTTPBearer()
 
+
 # Create a private endpoint
 @app.get("/private")
-async def private(token = Depends(token_auth_scheme)):
+async def private(token=Depends(token_auth_scheme)):
     return token.credentials
+
 
 # Create the MCP server with the token auth scheme
 mcp = FastApiMCP(
@@ -49,10 +52,11 @@ mcp = FastApiMCP(
 )
 
 # Mount the MCP server
-mcp.mount()
+mcp.mount_http()
+# mcp.mount_sse() # Or use SSE transport instead
 
 
 if __name__ == "__main__":
     import uvicorn
-    
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/examples/09_auth_example_auth0.py
+++ b/examples/09_auth_example_auth0.py
@@ -128,7 +128,7 @@ mcp = FastApiMCP(
 )
 
 # Mount the MCP server
-mcp.mount()
+mcp.mount_http()
 
 
 if __name__ == "__main__":

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -347,7 +347,7 @@ class FastApiMCP:
 
         assert isinstance(router, (FastAPI, APIRouter)), f"Invalid router type: {type(router)}"
 
-        http_transport = FastApiStreamableHttpTransport()
+        http_transport = FastApiStreamableHttpTransport(mcp_server=self.server)
         dependencies = self._auth_config.dependencies if self._auth_config else None
 
         self._register_mcp_endpoints_http(router, http_transport, mount_path, dependencies)

--- a/fastapi_mcp/transport/http.py
+++ b/fastapi_mcp/transport/http.py
@@ -1,0 +1,164 @@
+import logging
+import json
+
+from fastapi import Request, Response, HTTPException
+from mcp.server.streamable_http import StreamableHTTPServerTransport
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import JSONRPCMessage
+from pydantic import ValidationError
+from fastapi_mcp.types import HTTPRequestInfo
+
+logger = logging.getLogger(__name__)
+
+
+class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
+    def __init__(
+        self,
+        mcp_session_id: str | None = None,
+        is_json_response_enabled: bool = True,  # Default to JSON for HTTP transport
+        event_store=None,
+        security_settings: TransportSecuritySettings | None = None,
+    ):
+        super().__init__(
+            mcp_session_id=mcp_session_id,
+            is_json_response_enabled=is_json_response_enabled,
+            event_store=event_store,
+            security_settings=security_settings,
+        )
+        logger.debug(f"FastApiStreamableHttpTransport initialized with session_id: {mcp_session_id}")
+
+    async def handle_fastapi_request(self, request: Request) -> Response:
+        """
+        FastAPI-native request handler that adapts the SDK's handle_request method.
+
+        The approach here is necessarily different from FastApiSseTransport.
+        In FastApiSseTransport, we reimplement the SSE transport logic to have a more FastAPI-native transport.
+        It proved to be less bug-prone since it avoids deconstructing and reconstructing raw ASGI objects.
+
+        But, we took a different approach here because StreamableHTTPServerTransport handles more complexity,
+        and multiple request methods (GET/POST/DELETE), so we want to leverage that logic and avoid reimplementing.
+
+        So we use an enhanced adapter pattern: intercept and enhance POST requests for HTTPRequestInfo injection,
+        while delegating the complex protocol handling to the SDK.
+        """
+        logger.debug(f"Handling FastAPI request: {request.method} {request.url.path}")
+
+        if request.method == "POST":
+            return await self._handle_post_with_injection(request)
+        else:
+            # For GET and DELETE requests, delegate directly to SDK since they don't need injection
+            return await self._delegate_to_sdk(request)
+
+    async def _handle_post_with_injection(self, request: Request) -> Response:
+        """
+        Handle POST requests with HTTPRequestInfo injection.
+
+        This mirrors the approach in FastApiSseTransport.handle_fastapi_post_message()
+        to ensure consistency in how we handle authentication context and header forwarding.
+
+        The injection happens at the JSON-RPC message level, just like in SSE transport,
+        so that the downstream tool handlers receive the same request context regardless
+        of transport type.
+        """
+        try:
+            # Read and parse the request body first, just like SSE transport does
+            body = await request.body()
+            logger.debug(f"Received JSON: {body.decode()}")
+
+            try:
+                raw_message = json.loads(body)
+            except json.JSONDecodeError as e:
+                logger.error(f"Failed to parse JSON: {e}")
+                raise HTTPException(status_code=400, detail=f"Parse error: {str(e)}")
+
+            try:
+                message = JSONRPCMessage.model_validate(raw_message)
+            except ValidationError as e:
+                logger.error(f"Failed to validate message: {e}")
+                raise HTTPException(status_code=400, detail=f"Validation error: {str(e)}")
+
+            # HACK to inject the HTTP request info into the MCP message,
+            # so we can use it for auth.
+            # It is then used in our custom `LowlevelMCPServer.call_tool()` decorator.
+            if hasattr(message.root, "params") and message.root.params is not None:
+                message.root.params["_http_request_info"] = HTTPRequestInfo(
+                    method=request.method,
+                    path=request.url.path,
+                    headers=dict(request.headers),
+                    cookies=request.cookies,
+                    query_params=dict(request.query_params),
+                    body=body.decode(),
+                ).model_dump(mode="json")
+                logger.debug("Injected HTTPRequestInfo into message for auth context")
+
+            modified_body = message.model_dump_json(by_alias=True, exclude_none=True).encode()
+            modified_request = self._create_modified_request(request, modified_body)
+
+            # Delegate to SDK with the modified request
+            return await self._delegate_to_sdk(modified_request)
+
+        except HTTPException:
+            # Re-raise FastAPI HTTPExceptions directly for proper error handling
+            raise
+        except Exception:
+            logger.exception("Error processing POST request")
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    def _create_modified_request(self, original_request: Request, modified_body: bytes) -> Request:
+        """
+        Create a new Request object with modified body content.
+
+        This is necessary because we need to inject HTTPRequestInfo into the JSON-RPC message
+        before passing it to the SDK, but Request objects are immutable.
+        """
+
+        # Create a new receive callable that returns our modified body
+        async def modified_receive():
+            return {
+                "type": "http.request",
+                "body": modified_body,
+                "more_body": False,
+            }
+
+        # Create new request with modified receive
+        return Request(original_request.scope, modified_receive)
+
+    async def _delegate_to_sdk(self, request: Request) -> Response:
+        """
+        Delegate request handling to the underlying StreamableHTTPServerTransport.
+
+        This captures the ASGI response from the SDK and converts it to a FastAPI Response,
+        maintaining the adapter pattern while providing FastAPI-native integration.
+        """
+        # Capture the response from the SDK's handle_request method
+        response_started = False
+        response_status = 200
+        response_headers = []
+        response_body = b""
+
+        async def capture_send(message):
+            nonlocal response_started, response_status, response_headers, response_body
+
+            if message["type"] == "http.response.start":
+                response_started = True
+                response_status = message["status"]
+                response_headers = message.get("headers", [])
+            elif message["type"] == "http.response.body":
+                response_body += message.get("body", b"")
+
+        try:
+            # Delegate to the SDK's handle_request method with ASGI interface
+            await self.handle_request(request.scope, request.receive, capture_send)
+
+            # Convert the captured ASGI response to a FastAPI Response
+            headers_dict = {name.decode(): value.decode() for name, value in response_headers}
+
+            return Response(
+                content=response_body,
+                status_code=response_status,
+                headers=headers_dict,
+            )
+
+        except Exception as e:
+            logger.exception(f"Error in StreamableHTTPServerTransport: {e}")
+            raise HTTPException(status_code=500, detail="Internal server error")

--- a/fastapi_mcp/transport/http.py
+++ b/fastapi_mcp/transport/http.py
@@ -1,12 +1,8 @@
 import logging
-import json
 
 from fastapi import Request, Response, HTTPException
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 from mcp.server.transport_security import TransportSecuritySettings
-from mcp.types import JSONRPCMessage
-from pydantic import ValidationError
-from fastapi_mcp.types import HTTPRequestInfo
 
 logger = logging.getLogger(__name__)
 
@@ -29,107 +25,18 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
 
     async def handle_fastapi_request(self, request: Request) -> Response:
         """
-        FastAPI-native request handler that adapts the SDK's handle_request method.
-
-        The approach here is necessarily different from FastApiSseTransport.
+        The approach here is different from FastApiSseTransport.
         In FastApiSseTransport, we reimplement the SSE transport logic to have a more FastAPI-native transport.
         It proved to be less bug-prone since it avoids deconstructing and reconstructing raw ASGI objects.
 
         But, we took a different approach here because StreamableHTTPServerTransport handles more complexity,
         and multiple request methods (GET/POST/DELETE), so we want to leverage that logic and avoid reimplementing.
 
-        So we use an enhanced adapter pattern: intercept and enhance POST requests for HTTPRequestInfo injection,
-        while delegating the complex protocol handling to the SDK.
+        We still ensure it works natively with FastAPI by capturing the ASGI response from the SDK and converting
+        it to a FastAPI Response.
         """
         logger.debug(f"Handling FastAPI request: {request.method} {request.url.path}")
 
-        if request.method == "POST":
-            return await self._handle_post_with_injection(request)
-        else:
-            # For GET and DELETE requests, delegate directly to SDK since they don't need injection
-            return await self._delegate_to_sdk(request)
-
-    async def _handle_post_with_injection(self, request: Request) -> Response:
-        """
-        Handle POST requests with HTTPRequestInfo injection.
-
-        This mirrors the approach in FastApiSseTransport.handle_fastapi_post_message()
-        to ensure consistency in how we handle authentication context and header forwarding.
-
-        The injection happens at the JSON-RPC message level, just like in SSE transport,
-        so that the downstream tool handlers receive the same request context regardless
-        of transport type.
-        """
-        try:
-            # Read and parse the request body first, just like SSE transport does
-            body = await request.body()
-            logger.debug(f"Received JSON: {body.decode()}")
-
-            try:
-                raw_message = json.loads(body)
-            except json.JSONDecodeError as e:
-                logger.error(f"Failed to parse JSON: {e}")
-                raise HTTPException(status_code=400, detail=f"Parse error: {str(e)}")
-
-            try:
-                message = JSONRPCMessage.model_validate(raw_message)
-            except ValidationError as e:
-                logger.error(f"Failed to validate message: {e}")
-                raise HTTPException(status_code=400, detail=f"Validation error: {str(e)}")
-
-            # HACK to inject the HTTP request info into the MCP message,
-            # so we can use it for auth.
-            # It is then used in our custom `LowlevelMCPServer.call_tool()` decorator.
-            if hasattr(message.root, "params") and message.root.params is not None:
-                message.root.params["_http_request_info"] = HTTPRequestInfo(
-                    method=request.method,
-                    path=request.url.path,
-                    headers=dict(request.headers),
-                    cookies=request.cookies,
-                    query_params=dict(request.query_params),
-                    body=body.decode(),
-                ).model_dump(mode="json")
-                logger.debug("Injected HTTPRequestInfo into message for auth context")
-
-            modified_body = message.model_dump_json(by_alias=True, exclude_none=True).encode()
-            modified_request = self._create_modified_request(request, modified_body)
-
-            # Delegate to SDK with the modified request
-            return await self._delegate_to_sdk(modified_request)
-
-        except HTTPException:
-            # Re-raise FastAPI HTTPExceptions directly for proper error handling
-            raise
-        except Exception:
-            logger.exception("Error processing POST request")
-            raise HTTPException(status_code=500, detail="Internal server error")
-
-    def _create_modified_request(self, original_request: Request, modified_body: bytes) -> Request:
-        """
-        Create a new Request object with modified body content.
-
-        This is necessary because we need to inject HTTPRequestInfo into the JSON-RPC message
-        before passing it to the SDK, but Request objects are immutable.
-        """
-
-        # Create a new receive callable that returns our modified body
-        async def modified_receive():
-            return {
-                "type": "http.request",
-                "body": modified_body,
-                "more_body": False,
-            }
-
-        # Create new request with modified receive
-        return Request(original_request.scope, modified_receive)
-
-    async def _delegate_to_sdk(self, request: Request) -> Response:
-        """
-        Delegate request handling to the underlying StreamableHTTPServerTransport.
-
-        This captures the ASGI response from the SDK and converts it to a FastAPI Response,
-        maintaining the adapter pattern while providing FastAPI-native integration.
-        """
         # Capture the response from the SDK's handle_request method
         response_started = False
         response_status = 200

--- a/fastapi_mcp/transport/http.py
+++ b/fastapi_mcp/transport/http.py
@@ -74,7 +74,7 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
         response_headers = []
         response_body = b""
 
-        async def capture_send(message):
+        async def send_callback(message):
             nonlocal response_started, response_status, response_headers, response_body
 
             if message["type"] == "http.response.start":
@@ -86,7 +86,7 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
 
         try:
             # Delegate to the SDK's handle_request method with ASGI interface
-            await self.handle_request(request.scope, request.receive, capture_send)
+            await self.handle_request(request.scope, request.receive, send_callback)
 
             # Convert the captured ASGI response to a FastAPI Response
             headers_dict = {name.decode(): value.decode() for name, value in response_headers}
@@ -97,6 +97,6 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
                 headers=headers_dict,
             )
 
-        except Exception as e:
-            logger.exception(f"Error in StreamableHTTPServerTransport: {e}")
+        except Exception:
+            logger.exception("Error in StreamableHTTPServerTransport")
             raise HTTPException(status_code=500, detail="Internal server error")

--- a/fastapi_mcp/transport/http.py
+++ b/fastapi_mcp/transport/http.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import Request, Response, HTTPException
+from mcp.server.lowlevel.server import Server
 from mcp.server.streamable_http import StreamableHTTPServerTransport
 from mcp.server.transport_security import TransportSecuritySettings
 
@@ -14,6 +15,7 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
         is_json_response_enabled: bool = True,  # Default to JSON for HTTP transport
         event_store=None,
         security_settings: TransportSecuritySettings | None = None,
+        mcp_server: Server | None = None,
     ):
         super().__init__(
             mcp_session_id=mcp_session_id,
@@ -22,8 +24,10 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
             security_settings=security_settings,
         )
         logger.debug(f"FastApiStreamableHttpTransport initialized with session_id: {mcp_session_id}")
+        self._mcp_server = mcp_server
+        self._server_running = False
 
-    async def handle_fastapi_request(self, request: Request) -> Response:
+    async def handle_fastapi_request(self, request: Request, mcp_server: Server | None = None) -> Response:
         """
         The approach here is different from FastApiSseTransport.
         In FastApiSseTransport, we reimplement the SSE transport logic to have a more FastAPI-native transport.
@@ -36,6 +40,33 @@ class FastApiStreamableHttpTransport(StreamableHTTPServerTransport):
         it to a FastAPI Response.
         """
         logger.debug(f"Handling FastAPI request: {request.method} {request.url.path}")
+
+        # Use the stored server if available, or the passed one
+        server = self._mcp_server or mcp_server
+        if not server:
+            raise HTTPException(status_code=500, detail="No MCP server available")
+
+        # Initialize the transport if not already done
+        if not self._server_running:
+            import anyio
+
+            async def start_server():
+                self._server_running = True
+                async with self.connect() as (reader, writer):
+                    await server.run(
+                        reader,
+                        writer,
+                        server.create_initialization_options(notification_options=None, experimental_capabilities={}),
+                        raise_exceptions=False,
+                    )
+
+            # Start the server in a background task
+            import asyncio
+
+            asyncio.create_task(start_server())
+
+            # Give the server a moment to initialize
+            await anyio.sleep(0.1)
 
         # Capture the response from the SDK's handle_request method
         response_started = False

--- a/fastapi_mcp/transport/sse.py
+++ b/fastapi_mcp/transport/sse.py
@@ -9,7 +9,6 @@ from mcp.shared.message import SessionMessage
 from pydantic import ValidationError
 from mcp.server.sse import SseServerTransport
 from mcp.types import JSONRPCMessage, JSONRPCError, ErrorData
-from fastapi_mcp.types import HTTPRequestInfo
 
 
 logger = logging.getLogger(__name__)
@@ -59,19 +58,6 @@ class FastApiSseTransport(SseServerTransport):
 
         try:
             message = JSONRPCMessage.model_validate_json(body)
-
-            # HACK to inject the HTTP request info into the MCP message,
-            # so we can use it for auth.
-            # It is then used in our custom `LowlevelMCPServer.call_tool()` decorator.
-            if hasattr(message.root, "params") and message.root.params is not None:
-                message.root.params["_http_request_info"] = HTTPRequestInfo(
-                    method=request.method,
-                    path=request.url.path,
-                    headers=dict(request.headers),
-                    cookies=request.cookies,
-                    query_params=dict(request.query_params),
-                    body=body.decode(),
-                ).model_dump(mode="json")
 
             logger.debug(f"Validated client message: {message}")
         except ValidationError as err:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "fastapi>=0.100.0",
     "typer>=0.9.0",
     "rich>=13.0.0",
-    "mcp>=1.8.1",
+    "mcp>=1.12.0",
     "pydantic>=2.0.0",
     "pydantic-settings>=2.5.2",
     "uvicorn>=0.20.0",
@@ -49,6 +49,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pyjwt>=2.10.1",
     "cryptography>=44.0.2",
+    "types-jsonschema>=4.25.0.20250720",
 ]
 
 [project.urls]

--- a/tests/test_http_real_transport.py
+++ b/tests/test_http_real_transport.py
@@ -1,0 +1,169 @@
+import multiprocessing
+import socket
+import time
+import os
+import signal
+import atexit
+import sys
+import threading
+import coverage
+from typing import AsyncGenerator, Generator
+from fastapi import FastAPI
+import pytest
+import httpx
+import uvicorn
+from fastapi_mcp import FastApiMCP
+import mcp.types as types
+
+
+HOST = "127.0.0.1"
+SERVER_NAME = "Test MCP Server"
+
+
+def run_server(server_port: int, fastapi_app: FastAPI) -> None:
+    # Initialize coverage for subprocesses
+    cov = None
+    if "COVERAGE_PROCESS_START" in os.environ:
+        cov = coverage.Coverage(source=["fastapi_mcp"])
+        cov.start()
+
+        # Create a function to save coverage data at exit
+        def cleanup():
+            if cov:
+                cov.stop()
+                cov.save()
+
+        # Register multiple cleanup mechanisms to ensure coverage data is saved
+        atexit.register(cleanup)
+
+        # Setup signal handler for clean termination
+        def handle_signal(signum, frame):
+            cleanup()
+            sys.exit(0)
+
+        signal.signal(signal.SIGTERM, handle_signal)
+
+        # Backup thread to ensure coverage is written if process is terminated abruptly
+        def periodic_save():
+            while True:
+                time.sleep(1.0)
+                if cov:
+                    cov.save()
+
+        save_thread = threading.Thread(target=periodic_save)
+        save_thread.daemon = True
+        save_thread.start()
+
+    # Configure the server
+    mcp = FastApiMCP(
+        fastapi_app,
+        name=SERVER_NAME,
+        description="Test description",
+    )
+    mcp.mount_http()
+
+    # Start the server
+    server = uvicorn.Server(config=uvicorn.Config(app=fastapi_app, host=HOST, port=server_port, log_level="error"))
+    server.run()
+
+    # Give server time to start
+    while not server.started:
+        time.sleep(0.5)
+
+    # Ensure coverage is saved if exiting the normal way
+    if cov:
+        cov.stop()
+        cov.save()
+
+
+@pytest.fixture(params=["simple_fastapi_app", "simple_fastapi_app_with_root_path"])
+def server(request: pytest.FixtureRequest) -> Generator[str, None, None]:
+    # Ensure COVERAGE_PROCESS_START is set in the environment for subprocesses
+    coverage_rc = os.path.abspath(".coveragerc")
+    os.environ["COVERAGE_PROCESS_START"] = coverage_rc
+
+    # Get a free port
+    with socket.socket() as s:
+        s.bind((HOST, 0))
+        server_port = s.getsockname()[1]
+
+    # Use fork method to avoid pickling issues
+    ctx = multiprocessing.get_context("fork")
+
+    # Run the server in a subprocess
+    fastapi_app = request.getfixturevalue(request.param)
+    proc = ctx.Process(
+        target=run_server,
+        kwargs={"server_port": server_port, "fastapi_app": fastapi_app},
+        daemon=True,
+    )
+    proc.start()
+
+    # Wait for server to be running
+    max_attempts = 20
+    attempt = 0
+    while attempt < max_attempts:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.connect((HOST, server_port))
+                break
+        except ConnectionRefusedError:
+            time.sleep(0.1)
+            attempt += 1
+    else:
+        raise RuntimeError(f"Server failed to start after {max_attempts} attempts")
+
+    # Return the server URL
+    yield f"http://{HOST}:{server_port}{fastapi_app.root_path}"
+
+    # Signal the server to stop - added graceful shutdown before kill
+    try:
+        proc.terminate()
+        proc.join(timeout=2)
+    except (OSError, AttributeError):
+        pass
+
+    if proc.is_alive():
+        proc.kill()
+        proc.join(timeout=2)
+        if proc.is_alive():
+            raise RuntimeError("server process failed to terminate")
+
+
+@pytest.fixture()
+async def http_client(server: str) -> AsyncGenerator[httpx.AsyncClient, None]:
+    async with httpx.AsyncClient(base_url=server) as client:
+        yield client
+
+
+@pytest.mark.anyio
+async def test_http_initialize_request(http_client: httpx.AsyncClient, server: str) -> None:
+    mcp_path = "/mcp"  # Always use absolute path since server already includes root_path
+
+    response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {
+                    "sampling": None,
+                    "elicitation": None,
+                    "experimental": None,
+                    "roots": None,
+                },
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 200
+
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == 1
+    assert "result" in result
+    assert result["result"]["serverInfo"]["name"] == SERVER_NAME

--- a/tests/test_http_real_transport.py
+++ b/tests/test_http_real_transport.py
@@ -190,13 +190,21 @@ async def test_http_list_tools(http_client: httpx.AsyncClient, server: str) -> N
     )
     assert init_response.status_code == 200
 
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+    assert session_id is not None, "Server should return a session ID"
+
     initialized_response = await http_client.post(
         mcp_path,
         json={
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
     assert initialized_response.status_code == 202
 
@@ -207,7 +215,11 @@ async def test_http_list_tools(http_client: httpx.AsyncClient, server: str) -> N
             "method": "tools/list",
             "id": 2,
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
 
     assert response.status_code == 200
@@ -245,13 +257,21 @@ async def test_http_call_tool(http_client: httpx.AsyncClient, server: str) -> No
     )
     assert init_response.status_code == 200
 
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+    assert session_id is not None, "Server should return a session ID"
+
     initialized_response = await http_client.post(
         mcp_path,
         json={
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
     assert initialized_response.status_code == 202
 
@@ -266,7 +286,11 @@ async def test_http_call_tool(http_client: httpx.AsyncClient, server: str) -> No
                 "arguments": {"item_id": 1},
             },
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
 
     assert response.status_code == 200
@@ -305,13 +329,21 @@ async def test_http_ping(http_client: httpx.AsyncClient, server: str) -> None:
     )
     assert init_response.status_code == 200
 
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+    assert session_id is not None, "Server should return a session ID"
+
     initialized_response = await http_client.post(
         mcp_path,
         json={
             "jsonrpc": "2.0",
             "method": "notifications/initialized",
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
     assert initialized_response.status_code == 202
 
@@ -322,7 +354,11 @@ async def test_http_ping(http_client: httpx.AsyncClient, server: str) -> None:
             "method": "ping",
             "id": 4,
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
 
     assert response.status_code == 200
@@ -354,6 +390,27 @@ async def test_http_invalid_method(http_client: httpx.AsyncClient, server: str) 
     """Test error handling for invalid methods."""
     mcp_path = "/mcp"
 
+    # First initialize to get a session ID
+    init_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+    assert init_response.status_code == 200
+
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+    assert session_id is not None, "Server should return a session ID"
+
     response = await http_client.post(
         mcp_path,
         json={
@@ -361,7 +418,11 @@ async def test_http_invalid_method(http_client: httpx.AsyncClient, server: str) 
             "method": "invalid/method",
             "id": 5,
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
 
     assert response.status_code == 200
@@ -377,6 +438,27 @@ async def test_http_notification_handling(http_client: httpx.AsyncClient, server
     """Test that notifications return 202 Accepted without response body."""
     mcp_path = "/mcp"
 
+    # First initialize to get a session ID
+    init_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+    assert init_response.status_code == 200
+
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+    assert session_id is not None, "Server should return a session ID"
+
     response = await http_client.post(
         mcp_path,
         json={
@@ -384,7 +466,11 @@ async def test_http_notification_handling(http_client: httpx.AsyncClient, server
             "method": "notifications/cancelled",
             "params": {"requestId": "test-123"},
         },
-        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": session_id,
+        },
     )
 
     assert response.status_code == 202

--- a/tests/test_mcp_complex_app.py
+++ b/tests/test_mcp_complex_app.py
@@ -214,8 +214,5 @@ async def test_error_handling_missing_parameter(lowlevel_server_complex_app: Ser
         assert len(response.content) > 0
 
         text_content = next(c for c in response.content if isinstance(c, types.TextContent))
-        assert (
-            "422" in text_content.text
-            or "parameter" in text_content.text.lower()
-            or "field" in text_content.text.lower()
-        )
+        assert "input validation error" in text_content.text.lower(), "Expected an input validation error"
+        assert "required" in text_content.text.lower(), "Expected a missing required parameter error"

--- a/tests/test_mcp_simple_app.py
+++ b/tests/test_mcp_simple_app.py
@@ -112,7 +112,7 @@ async def test_error_handling(lowlevel_server_simple_app: Server):
 
         text_content = next(c for c in response.content if isinstance(c, types.TextContent))
         assert "item_id" in text_content.text.lower() or "missing" in text_content.text.lower()
-        assert "422" in text_content.text, "Expected a 422 status to appear in the response text"
+        assert "input validation error" in text_content.text.lower(), "Expected an input validation error"
 
 
 @pytest.mark.asyncio
@@ -368,3 +368,76 @@ async def test_custom_header_passthrough_to_tool_handler(fastapi_mcp_with_custom
             headers_arg = mock_request.call_args[0][4]  # headers are the 5th argument
             assert "X-Custom-Header" in headers_arg
             assert headers_arg["X-Custom-Header"] == "MyValue123"
+
+
+@pytest.mark.asyncio
+async def test_context_extraction_in_tool_handler(fastapi_mcp: FastApiMCP):
+    """Test that handle_call_tool extracts HTTP request info from MCP context."""
+    from unittest.mock import patch, MagicMock
+    import mcp.types as types
+    from mcp.server.lowlevel.server import request_ctx
+
+    # Create a fake HTTP request object with headers
+    fake_http_request = MagicMock()
+    fake_http_request.method = "POST"
+    fake_http_request.url.path = "/test"
+    fake_http_request.headers = {"Authorization": "Bearer token-123", "X-Custom": "custom-value-123"}
+    fake_http_request.cookies = {}
+    fake_http_request.query_params = {}
+
+    # Create a fake request context containing the HTTP request
+    fake_request_context = MagicMock()
+    fake_request_context.request = fake_http_request
+
+    # Test with authorization header extraction from context
+    token = request_ctx.set(fake_request_context)
+    try:
+        with patch.object(fastapi_mcp, "_execute_api_tool") as mock_execute:
+            mock_execute.return_value = [types.TextContent(type="text", text="success")]
+
+            # Create a CallToolRequest like the MCP protocol would
+            call_request = types.CallToolRequest(
+                method="tools/call", params=types.CallToolRequestParams(name="get_item", arguments={"item_id": 1})
+            )
+
+            try:
+                # Call the tool handler directly like the MCP server would
+                await fastapi_mcp.server.request_handlers[types.CallToolRequest](call_request)
+            except Exception:
+                pass
+
+            assert mock_execute.called, "The _execute_api_tool method was not called"
+
+            if mock_execute.called:
+                # Verify that HTTPRequestInfo was extracted from context and passed to _execute_api_tool
+                http_request_info = mock_execute.call_args.kwargs["http_request_info"]
+                assert http_request_info is not None, "HTTPRequestInfo should be extracted from context"
+                assert http_request_info.method == "POST"
+                assert http_request_info.path == "/test"
+                assert "Authorization" in http_request_info.headers
+                assert http_request_info.headers["Authorization"] == "Bearer token-123"
+                assert "X-Custom" in http_request_info.headers
+                assert http_request_info.headers["X-Custom"] == "custom-value-123"
+    finally:
+        # Clean up the context variable
+        request_ctx.reset(token)
+
+    # Test with missing request context (should still work but with None)
+    with patch.object(fastapi_mcp, "_execute_api_tool") as mock_execute:
+        mock_execute.return_value = [types.TextContent(type="text", text="success")]
+
+        call_request = types.CallToolRequest(
+            method="tools/call", params=types.CallToolRequestParams(name="get_item", arguments={"item_id": 1})
+        )
+
+        try:
+            await fastapi_mcp.server.request_handlers[types.CallToolRequest](call_request)
+        except Exception:
+            pass
+
+        assert mock_execute.called, "The _execute_api_tool method was not called"
+
+        if mock_execute.called:
+            # Verify that HTTPRequestInfo is None when context is not available
+            http_request_info = mock_execute.call_args.kwargs["http_request_info"]
+            assert http_request_info is None, "HTTPRequestInfo should be None when context is not available"

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815 },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
@@ -351,6 +360,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
     { name = "types-setuptools" },
 ]
 
@@ -358,7 +368,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.24.0" },
-    { name = "mcp", specifier = ">=1.8.1" },
+    { name = "mcp", specifier = ">=1.12.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.5.2" },
     { name = "requests", specifier = ">=2.25.0" },
@@ -378,6 +388,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "ruff", specifier = ">=0.9.10" },
+    { name = "types-jsonschema", specifier = ">=4.25.0.20250720" },
     { name = "types-setuptools", specifier = ">=75.8.2.20250305" },
 ]
 
@@ -464,6 +475,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/00/a297a868e9d0784450faa7365c2172a7d6110c763e30ba861867c32ae6a9/jsonschema-4.25.0.tar.gz", hash = "sha256:e63acf5c11762c0e6672ffb61482bdf57f0876684d8d249c0fe2d730d48bc55f", size = 356830 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/54/c86cd8e011fe98803d7e382fd67c0df5ceab8d2b7ad8c5a81524f791551c/jsonschema-4.25.0-py3-none-any.whl", hash = "sha256:24c2e8da302de79c8b9382fee3e76b355e44d2a4364bb207159ce10b517bd716", size = 89184 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/ce/46fbd9c8119cfc3581ee5643ea49464d168028cfb5caff5fc0596d0cf914/jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608", size = 15513 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/0e/b27cdbaccf30b890c40ed1da9fd4a3593a5cf94dae54fb34f8a4b74fcd3f/jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af", size = 18437 },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -477,22 +515,24 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.8.1"
+version = "1.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "httpx-sse" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/13/16b712e8a3be6a736b411df2fc6b4e75eb1d3e99b1cd57a3a1decf17f612/mcp-1.8.1.tar.gz", hash = "sha256:ec0646271d93749f784d2316fb5fe6102fb0d1be788ec70a9e2517e8f2722c0e", size = 265605 }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/16cef13b2e60d5f865fbc96372efb23dc8b0591f102dd55003b4ae62f9b1/mcp-1.12.1.tar.gz", hash = "sha256:d1d0bdeb09e4b17c1a72b356248bf3baf75ab10db7008ef865c4afbeb0eb810e", size = 425768 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/5d/91cf0d40e40ae9ecf8d4004e0f9611eea86085aa0b5505493e0ff53972da/mcp-1.8.1-py3-none-any.whl", hash = "sha256:948e03783859fa35abe05b9b6c0a1d5519be452fc079dc8d7f682549591c1770", size = 119761 },
+    { url = "https://files.pythonhosted.org/packages/b9/04/9a967a575518fc958bda1e34a52eae0c7f6accf3534811914fdaf57b0689/mcp-1.12.1-py3-none-any.whl", hash = "sha256:34147f62891417f8b000c39718add844182ba424c8eb2cea250b4267bda4b08b", size = 158463 },
 ]
 
 [[package]]
@@ -793,6 +833,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432 },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103 },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557 },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031 },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308 },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930 },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543 },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040 },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102 },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700 },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700 },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318 },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714 },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800 },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -837,6 +899,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775 },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 source = { registry = "https://pypi.org/simple" }
@@ -863,6 +939,132 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/aa/4456d84bbb54adc6a916fb10c9b374f78ac840337644e4a5eda229c81275/rpds_py-0.26.0.tar.gz", hash = "sha256:20dae58a859b0906f0685642e591056f1e787f3a8b39c8e8749a45dc7d26bdb0", size = 27385 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/31/1459645f036c3dfeacef89e8e5825e430c77dde8489f3b99eaafcd4a60f5/rpds_py-0.26.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:4c70c70f9169692b36307a95f3d8c0a9fcd79f7b4a383aad5eaa0e9718b79b37", size = 372466 },
+    { url = "https://files.pythonhosted.org/packages/dd/ff/3d0727f35836cc8773d3eeb9a46c40cc405854e36a8d2e951f3a8391c976/rpds_py-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:777c62479d12395bfb932944e61e915741e364c843afc3196b694db3d669fcd0", size = 357825 },
+    { url = "https://files.pythonhosted.org/packages/bf/ce/badc5e06120a54099ae287fa96d82cbb650a5f85cf247ffe19c7b157fd1f/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec671691e72dff75817386aa02d81e708b5a7ec0dec6669ec05213ff6b77e1bd", size = 381530 },
+    { url = "https://files.pythonhosted.org/packages/1e/a5/fa5d96a66c95d06c62d7a30707b6a4cfec696ab8ae280ee7be14e961e118/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6a1cb5d6ce81379401bbb7f6dbe3d56de537fb8235979843f0d53bc2e9815a79", size = 396933 },
+    { url = "https://files.pythonhosted.org/packages/00/a7/7049d66750f18605c591a9db47d4a059e112a0c9ff8de8daf8fa0f446bba/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4f789e32fa1fb6a7bf890e0124e7b42d1e60d28ebff57fe806719abb75f0e9a3", size = 513973 },
+    { url = "https://files.pythonhosted.org/packages/0e/f1/528d02c7d6b29d29fac8fd784b354d3571cc2153f33f842599ef0cf20dd2/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c55b0a669976cf258afd718de3d9ad1b7d1fe0a91cd1ab36f38b03d4d4aeaaf", size = 402293 },
+    { url = "https://files.pythonhosted.org/packages/15/93/fde36cd6e4685df2cd08508f6c45a841e82f5bb98c8d5ecf05649522acb5/rpds_py-0.26.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c70d9ec912802ecfd6cd390dadb34a9578b04f9bcb8e863d0a7598ba5e9e7ccc", size = 383787 },
+    { url = "https://files.pythonhosted.org/packages/69/f2/5007553aaba1dcae5d663143683c3dfd03d9395289f495f0aebc93e90f24/rpds_py-0.26.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3021933c2cb7def39d927b9862292e0f4c75a13d7de70eb0ab06efed4c508c19", size = 416312 },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/ce52c75c1e624a79e48a69e611f1c08844564e44c85db2b6f711d76d10ce/rpds_py-0.26.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8a7898b6ca3b7d6659e55cdac825a2e58c638cbf335cde41f4619e290dd0ad11", size = 558403 },
+    { url = "https://files.pythonhosted.org/packages/79/d5/e119db99341cc75b538bf4cb80504129fa22ce216672fb2c28e4a101f4d9/rpds_py-0.26.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:12bff2ad9447188377f1b2794772f91fe68bb4bbfa5a39d7941fbebdbf8c500f", size = 588323 },
+    { url = "https://files.pythonhosted.org/packages/93/94/d28272a0b02f5fe24c78c20e13bbcb95f03dc1451b68e7830ca040c60bd6/rpds_py-0.26.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:191aa858f7d4902e975d4cf2f2d9243816c91e9605070aeb09c0a800d187e323", size = 554541 },
+    { url = "https://files.pythonhosted.org/packages/93/e0/8c41166602f1b791da892d976057eba30685486d2e2c061ce234679c922b/rpds_py-0.26.0-cp310-cp310-win32.whl", hash = "sha256:b37a04d9f52cb76b6b78f35109b513f6519efb481d8ca4c321f6a3b9580b3f45", size = 220442 },
+    { url = "https://files.pythonhosted.org/packages/87/f0/509736bb752a7ab50fb0270c2a4134d671a7b3038030837e5536c3de0e0b/rpds_py-0.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:38721d4c9edd3eb6670437d8d5e2070063f305bfa2d5aa4278c51cedcd508a84", size = 231314 },
+    { url = "https://files.pythonhosted.org/packages/09/4c/4ee8f7e512030ff79fda1df3243c88d70fc874634e2dbe5df13ba4210078/rpds_py-0.26.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:9e8cb77286025bdb21be2941d64ac6ca016130bfdcd228739e8ab137eb4406ed", size = 372610 },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3dc16be00f14fc1f03c71b1d67c8df98263ab2710a2fbd65a6193214a527/rpds_py-0.26.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5e09330b21d98adc8ccb2dbb9fc6cb434e8908d4c119aeaa772cb1caab5440a0", size = 358032 },
+    { url = "https://files.pythonhosted.org/packages/e7/5a/7f1bf8f045da2866324a08ae80af63e64e7bfaf83bd31f865a7b91a58601/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c9c1b92b774b2e68d11193dc39620d62fd8ab33f0a3c77ecdabe19c179cdbc1", size = 381525 },
+    { url = "https://files.pythonhosted.org/packages/45/8a/04479398c755a066ace10e3d158866beb600867cacae194c50ffa783abd0/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:824e6d3503ab990d7090768e4dfd9e840837bae057f212ff9f4f05ec6d1975e7", size = 397089 },
+    { url = "https://files.pythonhosted.org/packages/72/88/9203f47268db488a1b6d469d69c12201ede776bb728b9d9f29dbfd7df406/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ad7fd2258228bf288f2331f0a6148ad0186b2e3643055ed0db30990e59817a6", size = 514255 },
+    { url = "https://files.pythonhosted.org/packages/f5/b4/01ce5d1e853ddf81fbbd4311ab1eff0b3cf162d559288d10fd127e2588b5/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0dc23bbb3e06ec1ea72d515fb572c1fea59695aefbffb106501138762e1e915e", size = 402283 },
+    { url = "https://files.pythonhosted.org/packages/34/a2/004c99936997bfc644d590a9defd9e9c93f8286568f9c16cdaf3e14429a7/rpds_py-0.26.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d80bf832ac7b1920ee29a426cdca335f96a2b5caa839811803e999b41ba9030d", size = 383881 },
+    { url = "https://files.pythonhosted.org/packages/05/1b/ef5fba4a8f81ce04c427bfd96223f92f05e6cd72291ce9d7523db3b03a6c/rpds_py-0.26.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0919f38f5542c0a87e7b4afcafab6fd2c15386632d249e9a087498571250abe3", size = 415822 },
+    { url = "https://files.pythonhosted.org/packages/16/80/5c54195aec456b292f7bd8aa61741c8232964063fd8a75fdde9c1e982328/rpds_py-0.26.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d422b945683e409000c888e384546dbab9009bb92f7c0b456e217988cf316107", size = 558347 },
+    { url = "https://files.pythonhosted.org/packages/f2/1c/1845c1b1fd6d827187c43afe1841d91678d7241cbdb5420a4c6de180a538/rpds_py-0.26.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:77a7711fa562ba2da1aa757e11024ad6d93bad6ad7ede5afb9af144623e5f76a", size = 587956 },
+    { url = "https://files.pythonhosted.org/packages/2e/ff/9e979329dd131aa73a438c077252ddabd7df6d1a7ad7b9aacf6261f10faa/rpds_py-0.26.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:238e8c8610cb7c29460e37184f6799547f7e09e6a9bdbdab4e8edb90986a2318", size = 554363 },
+    { url = "https://files.pythonhosted.org/packages/00/8b/d78cfe034b71ffbe72873a136e71acc7a831a03e37771cfe59f33f6de8a2/rpds_py-0.26.0-cp311-cp311-win32.whl", hash = "sha256:893b022bfbdf26d7bedb083efeea624e8550ca6eb98bf7fea30211ce95b9201a", size = 220123 },
+    { url = "https://files.pythonhosted.org/packages/94/c1/3c8c94c7dd3905dbfde768381ce98778500a80db9924731d87ddcdb117e9/rpds_py-0.26.0-cp311-cp311-win_amd64.whl", hash = "sha256:87a5531de9f71aceb8af041d72fc4cab4943648d91875ed56d2e629bef6d4c03", size = 231732 },
+    { url = "https://files.pythonhosted.org/packages/67/93/e936fbed1b734eabf36ccb5d93c6a2e9246fbb13c1da011624b7286fae3e/rpds_py-0.26.0-cp311-cp311-win_arm64.whl", hash = "sha256:de2713f48c1ad57f89ac25b3cb7daed2156d8e822cf0eca9b96a6f990718cc41", size = 221917 },
+    { url = "https://files.pythonhosted.org/packages/ea/86/90eb87c6f87085868bd077c7a9938006eb1ce19ed4d06944a90d3560fce2/rpds_py-0.26.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:894514d47e012e794f1350f076c427d2347ebf82f9b958d554d12819849a369d", size = 363933 },
+    { url = "https://files.pythonhosted.org/packages/63/78/4469f24d34636242c924626082b9586f064ada0b5dbb1e9d096ee7a8e0c6/rpds_py-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc921b96fa95a097add244da36a1d9e4f3039160d1d30f1b35837bf108c21136", size = 350447 },
+    { url = "https://files.pythonhosted.org/packages/ad/91/c448ed45efdfdade82348d5e7995e15612754826ea640afc20915119734f/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e1157659470aa42a75448b6e943c895be8c70531c43cb78b9ba990778955582", size = 384711 },
+    { url = "https://files.pythonhosted.org/packages/ec/43/e5c86fef4be7f49828bdd4ecc8931f0287b1152c0bb0163049b3218740e7/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:521ccf56f45bb3a791182dc6b88ae5f8fa079dd705ee42138c76deb1238e554e", size = 400865 },
+    { url = "https://files.pythonhosted.org/packages/55/34/e00f726a4d44f22d5c5fe2e5ddd3ac3d7fd3f74a175607781fbdd06fe375/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9def736773fd56b305c0eef698be5192c77bfa30d55a0e5885f80126c4831a15", size = 517763 },
+    { url = "https://files.pythonhosted.org/packages/52/1c/52dc20c31b147af724b16104500fba13e60123ea0334beba7b40e33354b4/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdad4ea3b4513b475e027be79e5a0ceac8ee1c113a1a11e5edc3c30c29f964d8", size = 406651 },
+    { url = "https://files.pythonhosted.org/packages/2e/77/87d7bfabfc4e821caa35481a2ff6ae0b73e6a391bb6b343db2c91c2b9844/rpds_py-0.26.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82b165b07f416bdccf5c84546a484cc8f15137ca38325403864bfdf2b5b72f6a", size = 386079 },
+    { url = "https://files.pythonhosted.org/packages/e3/d4/7f2200c2d3ee145b65b3cddc4310d51f7da6a26634f3ac87125fd789152a/rpds_py-0.26.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d04cab0a54b9dba4d278fe955a1390da3cf71f57feb78ddc7cb67cbe0bd30323", size = 421379 },
+    { url = "https://files.pythonhosted.org/packages/ae/13/9fdd428b9c820869924ab62236b8688b122baa22d23efdd1c566938a39ba/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:79061ba1a11b6a12743a2b0f72a46aa2758613d454aa6ba4f5a265cc48850158", size = 562033 },
+    { url = "https://files.pythonhosted.org/packages/f3/e1/b69686c3bcbe775abac3a4c1c30a164a2076d28df7926041f6c0eb5e8d28/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f405c93675d8d4c5ac87364bb38d06c988e11028a64b52a47158a355079661f3", size = 591639 },
+    { url = "https://files.pythonhosted.org/packages/5c/c9/1e3d8c8863c84a90197ac577bbc3d796a92502124c27092413426f670990/rpds_py-0.26.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dafd4c44b74aa4bed4b250f1aed165b8ef5de743bcca3b88fc9619b6087093d2", size = 557105 },
+    { url = "https://files.pythonhosted.org/packages/9f/c5/90c569649057622959f6dcc40f7b516539608a414dfd54b8d77e3b201ac0/rpds_py-0.26.0-cp312-cp312-win32.whl", hash = "sha256:3da5852aad63fa0c6f836f3359647870e21ea96cf433eb393ffa45263a170d44", size = 223272 },
+    { url = "https://files.pythonhosted.org/packages/7d/16/19f5d9f2a556cfed454eebe4d354c38d51c20f3db69e7b4ce6cff904905d/rpds_py-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:cf47cfdabc2194a669dcf7a8dbba62e37a04c5041d2125fae0233b720da6f05c", size = 234995 },
+    { url = "https://files.pythonhosted.org/packages/83/f0/7935e40b529c0e752dfaa7880224771b51175fce08b41ab4a92eb2fbdc7f/rpds_py-0.26.0-cp312-cp312-win_arm64.whl", hash = "sha256:20ab1ae4fa534f73647aad289003f1104092890849e0266271351922ed5574f8", size = 223198 },
+    { url = "https://files.pythonhosted.org/packages/6a/67/bb62d0109493b12b1c6ab00de7a5566aa84c0e44217c2d94bee1bd370da9/rpds_py-0.26.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:696764a5be111b036256c0b18cd29783fab22154690fc698062fc1b0084b511d", size = 363917 },
+    { url = "https://files.pythonhosted.org/packages/4b/f3/34e6ae1925a5706c0f002a8d2d7f172373b855768149796af87bd65dcdb9/rpds_py-0.26.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6c15d2080a63aaed876e228efe4f814bc7889c63b1e112ad46fdc8b368b9e1", size = 350073 },
+    { url = "https://files.pythonhosted.org/packages/75/83/1953a9d4f4e4de7fd0533733e041c28135f3c21485faaef56a8aadbd96b5/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:390e3170babf42462739a93321e657444f0862c6d722a291accc46f9d21ed04e", size = 384214 },
+    { url = "https://files.pythonhosted.org/packages/48/0e/983ed1b792b3322ea1d065e67f4b230f3b96025f5ce3878cc40af09b7533/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7da84c2c74c0f5bc97d853d9e17bb83e2dcafcff0dc48286916001cc114379a1", size = 400113 },
+    { url = "https://files.pythonhosted.org/packages/69/7f/36c0925fff6f660a80be259c5b4f5e53a16851f946eb080351d057698528/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4c5fe114a6dd480a510b6d3661d09d67d1622c4bf20660a474507aaee7eeeee9", size = 515189 },
+    { url = "https://files.pythonhosted.org/packages/13/45/cbf07fc03ba7a9b54662c9badb58294ecfb24f828b9732970bd1a431ed5c/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3100b3090269f3a7ea727b06a6080d4eb7439dca4c0e91a07c5d133bb1727ea7", size = 406998 },
+    { url = "https://files.pythonhosted.org/packages/6c/b0/8fa5e36e58657997873fd6a1cf621285ca822ca75b4b3434ead047daa307/rpds_py-0.26.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2c03c9b0c64afd0320ae57de4c982801271c0c211aa2d37f3003ff5feb75bb04", size = 385903 },
+    { url = "https://files.pythonhosted.org/packages/4b/f7/b25437772f9f57d7a9fbd73ed86d0dcd76b4c7c6998348c070d90f23e315/rpds_py-0.26.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5963b72ccd199ade6ee493723d18a3f21ba7d5b957017607f815788cef50eaf1", size = 419785 },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/63ffa55743dfcb4baf2e9e77a0b11f7f97ed96a54558fcb5717a4b2cd732/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9da4e873860ad5bab3291438525cae80169daecbfafe5657f7f5fb4d6b3f96b9", size = 561329 },
+    { url = "https://files.pythonhosted.org/packages/2f/07/1f4f5e2886c480a2346b1e6759c00278b8a69e697ae952d82ae2e6ee5db0/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5afaddaa8e8c7f1f7b4c5c725c0070b6eed0228f705b90a1732a48e84350f4e9", size = 590875 },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/e6639f1b91c3a55f8c41b47d73e6307051b6e246254a827ede730624c0f8/rpds_py-0.26.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4916dc96489616a6f9667e7526af8fa693c0fdb4f3acb0e5d9f4400eb06a47ba", size = 556636 },
+    { url = "https://files.pythonhosted.org/packages/05/4c/b3917c45566f9f9a209d38d9b54a1833f2bb1032a3e04c66f75726f28876/rpds_py-0.26.0-cp313-cp313-win32.whl", hash = "sha256:2a343f91b17097c546b93f7999976fd6c9d5900617aa848c81d794e062ab302b", size = 222663 },
+    { url = "https://files.pythonhosted.org/packages/e0/0b/0851bdd6025775aaa2365bb8de0697ee2558184c800bfef8d7aef5ccde58/rpds_py-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:0a0b60701f2300c81b2ac88a5fb893ccfa408e1c4a555a77f908a2596eb875a5", size = 234428 },
+    { url = "https://files.pythonhosted.org/packages/ed/e8/a47c64ed53149c75fb581e14a237b7b7cd18217e969c30d474d335105622/rpds_py-0.26.0-cp313-cp313-win_arm64.whl", hash = "sha256:257d011919f133a4746958257f2c75238e3ff54255acd5e3e11f3ff41fd14256", size = 222571 },
+    { url = "https://files.pythonhosted.org/packages/89/bf/3d970ba2e2bcd17d2912cb42874107390f72873e38e79267224110de5e61/rpds_py-0.26.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:529c8156d7506fba5740e05da8795688f87119cce330c244519cf706a4a3d618", size = 360475 },
+    { url = "https://files.pythonhosted.org/packages/82/9f/283e7e2979fc4ec2d8ecee506d5a3675fce5ed9b4b7cb387ea5d37c2f18d/rpds_py-0.26.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f53ec51f9d24e9638a40cabb95078ade8c99251945dad8d57bf4aabe86ecee35", size = 346692 },
+    { url = "https://files.pythonhosted.org/packages/e3/03/7e50423c04d78daf391da3cc4330bdb97042fc192a58b186f2d5deb7befd/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab504c4d654e4a29558eaa5bb8cea5fdc1703ea60a8099ffd9c758472cf913f", size = 379415 },
+    { url = "https://files.pythonhosted.org/packages/57/00/d11ee60d4d3b16808432417951c63df803afb0e0fc672b5e8d07e9edaaae/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fd0641abca296bc1a00183fe44f7fced8807ed49d501f188faa642d0e4975b83", size = 391783 },
+    { url = "https://files.pythonhosted.org/packages/08/b3/1069c394d9c0d6d23c5b522e1f6546b65793a22950f6e0210adcc6f97c3e/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69b312fecc1d017b5327afa81d4da1480f51c68810963a7336d92203dbb3d4f1", size = 512844 },
+    { url = "https://files.pythonhosted.org/packages/08/3b/c4fbf0926800ed70b2c245ceca99c49f066456755f5d6eb8863c2c51e6d0/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c741107203954f6fc34d3066d213d0a0c40f7bb5aafd698fb39888af277c70d8", size = 402105 },
+    { url = "https://files.pythonhosted.org/packages/1c/b0/db69b52ca07413e568dae9dc674627a22297abb144c4d6022c6d78f1e5cc/rpds_py-0.26.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc3e55a7db08dc9a6ed5fb7103019d2c1a38a349ac41901f9f66d7f95750942f", size = 383440 },
+    { url = "https://files.pythonhosted.org/packages/4c/e1/c65255ad5b63903e56b3bb3ff9dcc3f4f5c3badde5d08c741ee03903e951/rpds_py-0.26.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9e851920caab2dbcae311fd28f4313c6953993893eb5c1bb367ec69d9a39e7ed", size = 412759 },
+    { url = "https://files.pythonhosted.org/packages/e4/22/bb731077872377a93c6e93b8a9487d0406c70208985831034ccdeed39c8e/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dfbf280da5f876d0b00c81f26bedce274e72a678c28845453885a9b3c22ae632", size = 556032 },
+    { url = "https://files.pythonhosted.org/packages/e0/8b/393322ce7bac5c4530fb96fc79cc9ea2f83e968ff5f6e873f905c493e1c4/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1cc81d14ddfa53d7f3906694d35d54d9d3f850ef8e4e99ee68bc0d1e5fed9a9c", size = 585416 },
+    { url = "https://files.pythonhosted.org/packages/49/ae/769dc372211835bf759319a7aae70525c6eb523e3371842c65b7ef41c9c6/rpds_py-0.26.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dca83c498b4650a91efcf7b88d669b170256bf8017a5db6f3e06c2bf031f57e0", size = 554049 },
+    { url = "https://files.pythonhosted.org/packages/6b/f9/4c43f9cc203d6ba44ce3146246cdc38619d92c7bd7bad4946a3491bd5b70/rpds_py-0.26.0-cp313-cp313t-win32.whl", hash = "sha256:4d11382bcaf12f80b51d790dee295c56a159633a8e81e6323b16e55d81ae37e9", size = 218428 },
+    { url = "https://files.pythonhosted.org/packages/7e/8b/9286b7e822036a4a977f2f1e851c7345c20528dbd56b687bb67ed68a8ede/rpds_py-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff110acded3c22c033e637dd8896e411c7d3a11289b2edf041f86663dbc791e9", size = 231524 },
+    { url = "https://files.pythonhosted.org/packages/55/07/029b7c45db910c74e182de626dfdae0ad489a949d84a468465cd0ca36355/rpds_py-0.26.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:da619979df60a940cd434084355c514c25cf8eb4cf9a508510682f6c851a4f7a", size = 364292 },
+    { url = "https://files.pythonhosted.org/packages/13/d1/9b3d3f986216b4d1f584878dca15ce4797aaf5d372d738974ba737bf68d6/rpds_py-0.26.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ea89a2458a1a75f87caabefe789c87539ea4e43b40f18cff526052e35bbb4fdf", size = 350334 },
+    { url = "https://files.pythonhosted.org/packages/18/98/16d5e7bc9ec715fa9668731d0cf97f6b032724e61696e2db3d47aeb89214/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feac1045b3327a45944e7dcbeb57530339f6b17baff154df51ef8b0da34c8c12", size = 384875 },
+    { url = "https://files.pythonhosted.org/packages/f9/13/aa5e2b1ec5ab0e86a5c464d53514c0467bec6ba2507027d35fc81818358e/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b818a592bd69bfe437ee8368603d4a2d928c34cffcdf77c2e761a759ffd17d20", size = 399993 },
+    { url = "https://files.pythonhosted.org/packages/17/03/8021810b0e97923abdbab6474c8b77c69bcb4b2c58330777df9ff69dc559/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1a8b0dd8648709b62d9372fc00a57466f5fdeefed666afe3fea5a6c9539a0331", size = 516683 },
+    { url = "https://files.pythonhosted.org/packages/dc/b1/da8e61c87c2f3d836954239fdbbfb477bb7b54d74974d8f6fcb34342d166/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6d3498ad0df07d81112aa6ec6c95a7e7b1ae00929fb73e7ebee0f3faaeabad2f", size = 408825 },
+    { url = "https://files.pythonhosted.org/packages/38/bc/1fc173edaaa0e52c94b02a655db20697cb5fa954ad5a8e15a2c784c5cbdd/rpds_py-0.26.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4146ccb15be237fdef10f331c568e1b0e505f8c8c9ed5d67759dac58ac246", size = 387292 },
+    { url = "https://files.pythonhosted.org/packages/7c/eb/3a9bb4bd90867d21916f253caf4f0d0be7098671b6715ad1cead9fe7bab9/rpds_py-0.26.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a9a63785467b2d73635957d32a4f6e73d5e4df497a16a6392fa066b753e87387", size = 420435 },
+    { url = "https://files.pythonhosted.org/packages/cd/16/e066dcdb56f5632713445271a3f8d3d0b426d51ae9c0cca387799df58b02/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:de4ed93a8c91debfd5a047be327b7cc8b0cc6afe32a716bbbc4aedca9e2a83af", size = 562410 },
+    { url = "https://files.pythonhosted.org/packages/60/22/ddbdec7eb82a0dc2e455be44c97c71c232983e21349836ce9f272e8a3c29/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:caf51943715b12af827696ec395bfa68f090a4c1a1d2509eb4e2cb69abbbdb33", size = 590724 },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/95744085e65b7187d83f2fcb0bef70716a1ea0a9e5d8f7f39a86e5d83424/rpds_py-0.26.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4a59e5bc386de021f56337f757301b337d7ab58baa40174fb150accd480bc953", size = 558285 },
+    { url = "https://files.pythonhosted.org/packages/37/37/6309a75e464d1da2559446f9c811aa4d16343cebe3dbb73701e63f760caa/rpds_py-0.26.0-cp314-cp314-win32.whl", hash = "sha256:92c8db839367ef16a662478f0a2fe13e15f2227da3c1430a782ad0f6ee009ec9", size = 223459 },
+    { url = "https://files.pythonhosted.org/packages/d9/6f/8e9c11214c46098b1d1391b7e02b70bb689ab963db3b19540cba17315291/rpds_py-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:b0afb8cdd034150d4d9f53926226ed27ad15b7f465e93d7468caaf5eafae0d37", size = 236083 },
+    { url = "https://files.pythonhosted.org/packages/47/af/9c4638994dd623d51c39892edd9d08e8be8220a4b7e874fa02c2d6e91955/rpds_py-0.26.0-cp314-cp314-win_arm64.whl", hash = "sha256:ca3f059f4ba485d90c8dc75cb5ca897e15325e4e609812ce57f896607c1c0867", size = 223291 },
+    { url = "https://files.pythonhosted.org/packages/4d/db/669a241144460474aab03e254326b32c42def83eb23458a10d163cb9b5ce/rpds_py-0.26.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:5afea17ab3a126006dc2f293b14ffc7ef3c85336cf451564a0515ed7648033da", size = 361445 },
+    { url = "https://files.pythonhosted.org/packages/3b/2d/133f61cc5807c6c2fd086a46df0eb8f63a23f5df8306ff9f6d0fd168fecc/rpds_py-0.26.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:69f0c0a3df7fd3a7eec50a00396104bb9a843ea6d45fcc31c2d5243446ffd7a7", size = 347206 },
+    { url = "https://files.pythonhosted.org/packages/05/bf/0e8fb4c05f70273469eecf82f6ccf37248558526a45321644826555db31b/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:801a71f70f9813e82d2513c9a96532551fce1e278ec0c64610992c49c04c2dad", size = 380330 },
+    { url = "https://files.pythonhosted.org/packages/d4/a8/060d24185d8b24d3923322f8d0ede16df4ade226a74e747b8c7c978e3dd3/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df52098cde6d5e02fa75c1f6244f07971773adb4a26625edd5c18fee906fa84d", size = 392254 },
+    { url = "https://files.pythonhosted.org/packages/b9/7b/7c2e8a9ee3e6bc0bae26bf29f5219955ca2fbb761dca996a83f5d2f773fe/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9bc596b30f86dc6f0929499c9e574601679d0341a0108c25b9b358a042f51bca", size = 516094 },
+    { url = "https://files.pythonhosted.org/packages/75/d6/f61cafbed8ba1499b9af9f1777a2a199cd888f74a96133d8833ce5eaa9c5/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9dfbe56b299cf5875b68eb6f0ebaadc9cac520a1989cac0db0765abfb3709c19", size = 402889 },
+    { url = "https://files.pythonhosted.org/packages/92/19/c8ac0a8a8df2dd30cdec27f69298a5c13e9029500d6d76718130f5e5be10/rpds_py-0.26.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac64f4b2bdb4ea622175c9ab7cf09444e412e22c0e02e906978b3b488af5fde8", size = 384301 },
+    { url = "https://files.pythonhosted.org/packages/41/e1/6b1859898bc292a9ce5776016c7312b672da00e25cec74d7beced1027286/rpds_py-0.26.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:181ef9b6bbf9845a264f9aa45c31836e9f3c1f13be565d0d010e964c661d1e2b", size = 412891 },
+    { url = "https://files.pythonhosted.org/packages/ef/b9/ceb39af29913c07966a61367b3c08b4f71fad841e32c6b59a129d5974698/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:49028aa684c144ea502a8e847d23aed5e4c2ef7cadfa7d5eaafcb40864844b7a", size = 557044 },
+    { url = "https://files.pythonhosted.org/packages/2f/27/35637b98380731a521f8ec4f3fd94e477964f04f6b2f8f7af8a2d889a4af/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e5d524d68a474a9688336045bbf76cb0def88549c1b2ad9dbfec1fb7cfbe9170", size = 585774 },
+    { url = "https://files.pythonhosted.org/packages/52/d9/3f0f105420fecd18551b678c9a6ce60bd23986098b252a56d35781b3e7e9/rpds_py-0.26.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c1851f429b822831bd2edcbe0cfd12ee9ea77868f8d3daf267b189371671c80e", size = 554886 },
+    { url = "https://files.pythonhosted.org/packages/6b/c5/347c056a90dc8dd9bc240a08c527315008e1b5042e7a4cf4ac027be9d38a/rpds_py-0.26.0-cp314-cp314t-win32.whl", hash = "sha256:7bdb17009696214c3b66bb3590c6d62e14ac5935e53e929bcdbc5a495987a84f", size = 219027 },
+    { url = "https://files.pythonhosted.org/packages/75/04/5302cea1aa26d886d34cadbf2dc77d90d7737e576c0065f357b96dc7a1a6/rpds_py-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f14440b9573a6f76b4ee4770c13f0b5921f71dde3b6fcb8dabbefd13b7fe05d7", size = 232821 },
+    { url = "https://files.pythonhosted.org/packages/ef/9a/1f033b0b31253d03d785b0cd905bc127e555ab496ea6b4c7c2e1f951f2fd/rpds_py-0.26.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3c0909c5234543ada2515c05dc08595b08d621ba919629e94427e8e03539c958", size = 373226 },
+    { url = "https://files.pythonhosted.org/packages/58/29/5f88023fd6aaaa8ca3c4a6357ebb23f6f07da6079093ccf27c99efce87db/rpds_py-0.26.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:c1fb0cda2abcc0ac62f64e2ea4b4e64c57dfd6b885e693095460c61bde7bb18e", size = 359230 },
+    { url = "https://files.pythonhosted.org/packages/6c/6c/13eaebd28b439da6964dde22712b52e53fe2824af0223b8e403249d10405/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84d142d2d6cf9b31c12aa4878d82ed3b2324226270b89b676ac62ccd7df52d08", size = 382363 },
+    { url = "https://files.pythonhosted.org/packages/55/fc/3bb9c486b06da19448646f96147796de23c5811ef77cbfc26f17307b6a9d/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a547e21c5610b7e9093d870be50682a6a6cf180d6da0f42c47c306073bfdbbf6", size = 397146 },
+    { url = "https://files.pythonhosted.org/packages/15/18/9d1b79eb4d18e64ba8bba9e7dec6f9d6920b639f22f07ee9368ca35d4673/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:35e9a70a0f335371275cdcd08bc5b8051ac494dd58bff3bbfb421038220dc871", size = 514804 },
+    { url = "https://files.pythonhosted.org/packages/4f/5a/175ad7191bdbcd28785204621b225ad70e85cdfd1e09cc414cb554633b21/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0dfa6115c6def37905344d56fb54c03afc49104e2ca473d5dedec0f6606913b4", size = 402820 },
+    { url = "https://files.pythonhosted.org/packages/11/45/6a67ecf6d61c4d4aff4bc056e864eec4b2447787e11d1c2c9a0242c6e92a/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:313cfcd6af1a55a286a3c9a25f64af6d0e46cf60bc5798f1db152d97a216ff6f", size = 384567 },
+    { url = "https://files.pythonhosted.org/packages/a1/ba/16589da828732b46454c61858950a78fe4c931ea4bf95f17432ffe64b241/rpds_py-0.26.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f7bf2496fa563c046d05e4d232d7b7fd61346e2402052064b773e5c378bf6f73", size = 416520 },
+    { url = "https://files.pythonhosted.org/packages/81/4b/00092999fc7c0c266045e984d56b7314734cc400a6c6dc4d61a35f135a9d/rpds_py-0.26.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:aa81873e2c8c5aa616ab8e017a481a96742fdf9313c40f14338ca7dbf50cb55f", size = 559362 },
+    { url = "https://files.pythonhosted.org/packages/96/0c/43737053cde1f93ac4945157f7be1428724ab943e2132a0d235a7e161d4e/rpds_py-0.26.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:68ffcf982715f5b5b7686bdd349ff75d422e8f22551000c24b30eaa1b7f7ae84", size = 588113 },
+    { url = "https://files.pythonhosted.org/packages/46/46/8e38f6161466e60a997ed7e9951ae5de131dedc3cf778ad35994b4af823d/rpds_py-0.26.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6188de70e190847bb6db3dc3981cbadff87d27d6fe9b4f0e18726d55795cee9b", size = 555429 },
+    { url = "https://files.pythonhosted.org/packages/2c/ac/65da605e9f1dd643ebe615d5bbd11b6efa1d69644fc4bf623ea5ae385a82/rpds_py-0.26.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:1c962145c7473723df9722ba4c058de12eb5ebedcb4e27e7d902920aa3831ee8", size = 231950 },
+    { url = "https://files.pythonhosted.org/packages/51/f2/b5c85b758a00c513bb0389f8fc8e61eb5423050c91c958cdd21843faa3e6/rpds_py-0.26.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:f61a9326f80ca59214d1cceb0a09bb2ece5b2563d4e0cd37bfd5515c28510674", size = 373505 },
+    { url = "https://files.pythonhosted.org/packages/23/e0/25db45e391251118e915e541995bb5f5ac5691a3b98fb233020ba53afc9b/rpds_py-0.26.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:183f857a53bcf4b1b42ef0f57ca553ab56bdd170e49d8091e96c51c3d69ca696", size = 359468 },
+    { url = "https://files.pythonhosted.org/packages/0b/73/dd5ee6075bb6491be3a646b301dfd814f9486d924137a5098e61f0487e16/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:941c1cfdf4799d623cf3aa1d326a6b4fdb7a5799ee2687f3516738216d2262fb", size = 382680 },
+    { url = "https://files.pythonhosted.org/packages/2f/10/84b522ff58763a5c443f5bcedc1820240e454ce4e620e88520f04589e2ea/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72a8d9564a717ee291f554eeb4bfeafe2309d5ec0aa6c475170bdab0f9ee8e88", size = 397035 },
+    { url = "https://files.pythonhosted.org/packages/06/ea/8667604229a10a520fcbf78b30ccc278977dcc0627beb7ea2c96b3becef0/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:511d15193cbe013619dd05414c35a7dedf2088fcee93c6bbb7c77859765bd4e8", size = 514922 },
+    { url = "https://files.pythonhosted.org/packages/24/e6/9ed5b625c0661c4882fc8cdf302bf8e96c73c40de99c31e0b95ed37d508c/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aea1f9741b603a8d8fedb0ed5502c2bc0accbc51f43e2ad1337fe7259c2b77a5", size = 402822 },
+    { url = "https://files.pythonhosted.org/packages/8a/58/212c7b6fd51946047fb45d3733da27e2fa8f7384a13457c874186af691b1/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4019a9d473c708cf2f16415688ef0b4639e07abaa569d72f74745bbeffafa2c7", size = 384336 },
+    { url = "https://files.pythonhosted.org/packages/aa/f5/a40ba78748ae8ebf4934d4b88e77b98497378bc2c24ba55ebe87a4e87057/rpds_py-0.26.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:093d63b4b0f52d98ebae33b8c50900d3d67e0666094b1be7a12fffd7f65de74b", size = 416871 },
+    { url = "https://files.pythonhosted.org/packages/d5/a6/33b1fc0c9f7dcfcfc4a4353daa6308b3ece22496ceece348b3e7a7559a09/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2abe21d8ba64cded53a2a677e149ceb76dcf44284202d737178afe7ba540c1eb", size = 559439 },
+    { url = "https://files.pythonhosted.org/packages/71/2d/ceb3f9c12f8cfa56d34995097f6cd99da1325642c60d1b6680dd9df03ed8/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:4feb7511c29f8442cbbc28149a92093d32e815a28aa2c50d333826ad2a20fdf0", size = 588380 },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/9de62c2150ca8e2e5858acf3f4f4d0d180a38feef9fdab4078bea63d8dba/rpds_py-0.26.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e99685fc95d386da368013e7fb4269dd39c30d99f812a8372d62f244f662709c", size = 555334 },
 ]
 
 [[package]]
@@ -994,6 +1196,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6f/3991f0f1c7fcb2df31aef28e0594d8d54b05393a0e4e34c65e475c2a5d41/typer-0.15.2.tar.gz", hash = "sha256:ab2fab47533a813c49fe1f16b1a370fd5819099c00b119e0633df65f22144ba5", size = 100711 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/fc/5b29fea8cee020515ca82cc68e3b8e1e34bb19a3535ad854cac9257b414c/typer-0.15.2-py3-none-any.whl", hash = "sha256:46a499c6107d645a9c13f7ee46c5d5096cae6f5fc57dd11eccbbb9ae3e44ddfc", size = 45061 },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.25.0.20250720"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/f3/7dba3ea10a52f57f6bbc7905b34ae0b04fd1487448c089c96aab710d745d/types_jsonschema-4.25.0.20250720.tar.gz", hash = "sha256:765a3b6144798fe3161fd8cbe570a756ed3e8c0e5adb7c09693eb49faad39dbd", size = 15470 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/b6/e9ca8ba6803992fd5a8a83a21ae61e7d050cc24b51d33215860510b561d9/types_jsonschema-4.25.0.20250720-py3-none-any.whl", hash = "sha256:7d7897c715310d8bf9ae27a2cedba78bbb09e4cad83ce06d2aa79b73a88941df", size = 15769 },
 ]
 
 [[package]]


### PR DESCRIPTION
## 🚀 Add Streamable HTTP Transport Support

This PR adds support for **Streamable HTTP transport** as the new primary transport method.
#61 

### ⚠️ Breaking Changes

- **`mount()` method is now deprecated** and will be removed in a future version
- New explicit methods:
  - `mount_http()` - **Recommended** for HTTP transport (new default)
  - `mount_sse()` - For SSE transport (backwards compatibility)
- For backwards compatibility, the old `mount()` method defaults to SSE transport with a deprecation warning

### 🛠 More Fixes

- **Input Validation**: Leverage the SDK's input validation to catch input errors BEFORE they reach the FastAPI server
- **Session management**: Leverage the SDK's MCP session management capabilities for both HTTP and SSE
- **Request Context**: Leverage the SDK's capability to forward `request_context` to use the HTTP request information (such as auth) in tool handlers.
- **Security**: Built-in support for transport security settings and proper session validation
