### PR TITLE
feat: add include_response_info parameter to control response documen…

### DIFF
--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -18,6 +18,7 @@ def convert_openapi_to_mcp_tools(
     openapi_schema: Dict[str, Any],
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    include_response_info: bool = True,
 ) -> Tuple[List[types.Tool], Dict[str, Dict[str, Any]]]:
     """
     Convert OpenAPI operations to MCP tools.
@@ -26,6 +27,7 @@ def convert_openapi_to_mcp_tools(
         openapi_schema: The OpenAPI schema
         describe_all_responses: Whether to include all possible response schemas in tool descriptions
         describe_full_response_schema: Whether to include full response schema in tool descriptions
+        include_response_info: Whether to include response information in tool descriptions
 
     Returns:
         A tuple containing:
@@ -70,7 +72,7 @@ def convert_openapi_to_mcp_tools(
 
             # Add response information to the description
             responses = operation.get("responses", {})
-            if responses:
+            if responses and include_response_info:
                 response_info = "\n\n### Responses:\n"
 
                 # Find the success response

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -46,6 +46,10 @@ class FastApiMCP:
             bool,
             Doc("Whether to include full json schema for responses in tool descriptions"),
         ] = False,
+        include_response_info: Annotated[
+            bool,
+            Doc("Whether to include response information in tool descriptions"),
+        ] = True,
         http_client: Annotated[
             Optional[httpx.AsyncClient],
             Doc(
@@ -103,6 +107,7 @@ class FastApiMCP:
         self._base_url = "http://apiserver"
         self._describe_all_responses = describe_all_responses
         self._describe_full_response_schema = describe_full_response_schema
+        self._include_response_info = include_response_info
         self._include_operations = include_operations
         self._exclude_operations = exclude_operations
         self._include_tags = include_tags
@@ -136,6 +141,7 @@ class FastApiMCP:
             openapi_schema,
             describe_all_responses=self._describe_all_responses,
             describe_full_response_schema=self._describe_full_response_schema,
+            include_response_info=self._include_response_info,
         )
 
         # Filter tools based on operation IDs and tags


### PR DESCRIPTION
## Describe your changes
Add `include_response_info` parameter to `FastApiMCP` and `convert_openapi_to_mcp_tools` to control whether response information is included in tool descriptions. When set to False, completely removes all response documentation (status codes, examples, schemas) from tool descriptions to reduce context consumption.
## Issue ticket number and link (if applicable)
https://github.com/tadata-org/fastapi_mcp/issues/212
## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [x] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass
