### PR TITLE
fix: resolve circular reference recursion in schema resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - **Skip Deprecated APIs**: Automatically exclude deprecated operations (enabled by default) ([PR #180](https://github.com/tadata-org/fastapi_mcp/pull/180) 🔄)
 - **Structured Content Response**: Return structured JSON responses instead of text content ([PR #230](https://github.com/tadata-org/fastapi_mcp/pull/230) 🔄)
 - **Response Info Control**: Fine-grained control over response information in tool descriptions ([PR #215](https://github.com/tadata-org/fastapi_mcp/pull/215) 🔄)
+- **Output Schema Support**: Include outputSchema in MCP tools for better LLM understanding ([feature/output-schema-support](https://github.com/Edison-A-N/fastapi_mcp/tree/feature/output-schema-support) ⏳)
 
 These features are available in the `feature-test` branch.
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 **Built by [@Edison](https://github.com/Edison-A-N)**
 
-- **Stateless Mode**: Force stateless transport by ignoring mcp-session-id headers
-- **Skip Deprecated APIs**: Automatically exclude deprecated operations (enabled by default)
-- **Structured Content Response**: Return structured JSON responses instead of text content
-- **Response Info Control**: Fine-grained control over response information in tool descriptions
+- **Stateless Mode**: Force stateless transport by ignoring mcp-session-id headers ([PR #213](https://github.com/tadata-org/fastapi_mcp/pull/213) 🔄)
+- **Skip Deprecated APIs**: Automatically exclude deprecated operations (enabled by default) ([PR #180](https://github.com/tadata-org/fastapi_mcp/pull/180) 🔄)
+- **Structured Content Response**: Return structured JSON responses instead of text content ([PR #230](https://github.com/tadata-org/fastapi_mcp/pull/230) 🔄)
+- **Response Info Control**: Fine-grained control over response information in tool descriptions ([PR #215](https://github.com/tadata-org/fastapi_mcp/pull/215) 🔄)
 
 These features are available in the `feature-test` branch.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
+## 🚀 Enhanced Features (feature-test branch)
+
+**Built by [@Edison](https://github.com/Edison-A-N)**
+
+- **Stateless Mode**: Force stateless transport by ignoring mcp-session-id headers
+- **Skip Deprecated APIs**: Automatically exclude deprecated operations (enabled by default)
+- **Structured Content Response**: Return structured JSON responses instead of text content
+- **Response Info Control**: Fine-grained control over response information in tool descriptions
+
+These features are available in the `feature-test` branch.
+
+---
+
 <p align="center"><a href="https://github.com/tadata-org/fastapi_mcp"><img src="https://github.com/user-attachments/assets/7e44e98b-a0ba-4aff-a68a-4ffee3a6189c" alt="fastapi-to-mcp" height=100/></a></p>
 
 <div align="center">

--- a/examples/10_output_schema_example.py
+++ b/examples/10_output_schema_example.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Example demonstrating the new outputSchema feature in fastapi-mcp.
+
+This example shows how the convert_openapi_to_mcp_tools function now automatically
+extracts and includes outputSchema information from FastAPI response models.
+"""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Optional
+from fastapi_mcp.openapi.convert import convert_openapi_to_mcp_tools
+from fastapi.openapi.utils import get_openapi
+import json
+
+
+# Define response models
+class Item(BaseModel):
+    id: int
+    name: str
+    description: Optional[str] = None
+    price: float
+    tags: List[str] = []
+
+
+class ItemList(BaseModel):
+    items: List[Item]
+    total: int
+    page: int
+    size: int
+
+
+class ErrorResponse(BaseModel):
+    error: str
+    message: str
+    details: Optional[dict] = None
+
+
+# Create FastAPI app
+app = FastAPI(title="Output Schema Example", description="Example showing outputSchema extraction", version="1.0.0")
+
+
+@app.get(
+    "/items",
+    response_model=ItemList,
+    operation_id="list_items",
+    summary="List all items",
+    description="Retrieve a paginated list of items",
+)
+async def list_items(page: int = 1, size: int = 10):
+    """List all items with pagination."""
+    return ItemList(
+        items=[
+            Item(id=1, name="Item 1", price=10.99, tags=["electronics"]),
+            Item(id=2, name="Item 2", price=20.50, tags=["clothing"]),
+        ],
+        total=2,
+        page=page,
+        size=size,
+    )
+
+
+@app.get(
+    "/items/{item_id}",
+    response_model=Item,
+    operation_id="get_item",
+    summary="Get a specific item",
+    description="Retrieve detailed information about a specific item",
+)
+async def get_item(item_id: int):
+    """Get a specific item by ID."""
+    return Item(id=item_id, name=f"Item {item_id}", price=15.99, tags=["electronics"])
+
+
+@app.post(
+    "/items",
+    response_model=Item,
+    operation_id="create_item",
+    summary="Create a new item",
+    description="Create a new item in the system",
+)
+async def create_item(item: Item):
+    """Create a new item."""
+    return item
+
+
+@app.delete(
+    "/items/{item_id}",
+    operation_id="delete_item",
+    summary="Delete an item",
+    description="Delete an item from the system",
+)
+async def delete_item(item_id: int):
+    """Delete an item by ID."""
+    return {"message": f"Item {item_id} deleted successfully"}
+
+
+def main():
+    """Demonstrate the outputSchema feature."""
+    print("=== Output Schema Example ===\n")
+
+    # Generate OpenAPI schema
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # Convert to MCP tools with output schema enabled (default)
+    tools, operation_map = convert_openapi_to_mcp_tools(openapi_schema, include_output_schema=True)
+
+    print(f"Generated {len(tools)} MCP tools:\n")
+
+    for tool in tools:
+        print(f"Tool: {tool.name}")
+        print(f"Description: {tool.description[:100]}...")
+
+        if tool.inputSchema:
+            print(f"Input Schema: {json.dumps(tool.inputSchema, indent=2)}")
+        else:
+            print("Input Schema: None")
+
+        if tool.outputSchema:
+            print(f"Output Schema: {json.dumps(tool.outputSchema, indent=2)}")
+        else:
+            print("Output Schema: None")
+
+        print("-" * 50)
+
+    print("\n=== Key Features ===")
+    print("1. Tools with response models (list_items, get_item, create_item) have outputSchema")
+    print("2. Tools without response models (delete_item) have outputSchema=None")
+    print("3. outputSchema contains cleaned JSON schema from FastAPI response models")
+    print("4. This helps LLMs understand the expected output structure")
+    print("5. Use include_output_schema=False to disable outputSchema generation")
+
+    # Demonstrate the include_output_schema parameter
+    print("\n=== Demonstrating include_output_schema parameter ===")
+
+    # Convert without output schema
+    tools_without_schema, _ = convert_openapi_to_mcp_tools(openapi_schema, include_output_schema=False)
+
+    print(f"\nTools without outputSchema: {len(tools_without_schema)}")
+    for tool in tools_without_schema:
+        print(f"  {tool.name}: outputSchema = {tool.outputSchema}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -46,6 +46,11 @@ def convert_openapi_to_mcp_tools(
                 logger.warning(f"Skipping non-HTTP method: {method}")
                 continue
 
+            is_deprecated = operation.get("deprecated", False)
+            if is_deprecated:
+                logger.warning(f"Skipping deprecated operation: {method} {path}")
+                continue
+
             # Get operation metadata
             operation_id = operation.get("operationId")
             if not operation_id:

--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -18,6 +18,7 @@ def convert_openapi_to_mcp_tools(
     openapi_schema: Dict[str, Any],
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    include_response_info: bool = True,
 ) -> Tuple[List[types.Tool], Dict[str, Dict[str, Any]]]:
     """
     Convert OpenAPI operations to MCP tools.
@@ -26,6 +27,7 @@ def convert_openapi_to_mcp_tools(
         openapi_schema: The OpenAPI schema
         describe_all_responses: Whether to include all possible response schemas in tool descriptions
         describe_full_response_schema: Whether to include full response schema in tool descriptions
+        include_response_info: Whether to include response information in tool descriptions
 
     Returns:
         A tuple containing:
@@ -70,7 +72,7 @@ def convert_openapi_to_mcp_tools(
 
             # Add response information to the description
             responses = operation.get("responses", {})
-            if responses:
+            if responses and include_response_info:
                 response_info = "\n\n### Responses:\n"
 
                 # Find the success response

--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -18,6 +18,7 @@ def convert_openapi_to_mcp_tools(
     openapi_schema: Dict[str, Any],
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    ignore_deprecated: bool = True,
 ) -> Tuple[List[types.Tool], Dict[str, Dict[str, Any]]]:
     """
     Convert OpenAPI operations to MCP tools.
@@ -26,6 +27,7 @@ def convert_openapi_to_mcp_tools(
         openapi_schema: The OpenAPI schema
         describe_all_responses: Whether to include all possible response schemas in tool descriptions
         describe_full_response_schema: Whether to include full response schema in tool descriptions
+        ignore_deprecated: Whether to ignore deprecated operations when converting to MCP tools
 
     Returns:
         A tuple containing:
@@ -47,7 +49,7 @@ def convert_openapi_to_mcp_tools(
                 continue
 
             is_deprecated = operation.get("deprecated", False)
-            if is_deprecated:
+            if is_deprecated and ignore_deprecated:
                 logger.warning(f"Skipping deprecated operation: {method} {path}")
                 continue
 

--- a/fastapi_mcp/openapi/convert.py
+++ b/fastapi_mcp/openapi/convert.py
@@ -18,6 +18,7 @@ def convert_openapi_to_mcp_tools(
     openapi_schema: Dict[str, Any],
     describe_all_responses: bool = False,
     describe_full_response_schema: bool = False,
+    include_output_schema: bool = False,
 ) -> Tuple[List[types.Tool], Dict[str, Dict[str, Any]]]:
     """
     Convert OpenAPI operations to MCP tools.
@@ -26,6 +27,7 @@ def convert_openapi_to_mcp_tools(
         openapi_schema: The OpenAPI schema
         describe_all_responses: Whether to include all possible response schemas in tool descriptions
         describe_full_response_schema: Whether to include full response schema in tool descriptions
+        include_output_schema: Whether to include outputSchema in MCP tools, defaults to False for backwards compatibility
 
     Returns:
         A tuple containing:
@@ -259,8 +261,38 @@ def convert_openapi_to_mcp_tools(
             if required_props:
                 input_schema["required"] = required_props
 
+            # Extract output schema from responses
+            output_schema = None
+            if include_output_schema:
+                responses = operation.get("responses", {})
+                if responses:
+                    # Find the success response (2xx status codes)
+                    success_codes = range(200, 300)
+                    success_response = None
+                    for status_code in success_codes:
+                        if str(status_code) in responses:
+                            success_response = responses[str(status_code)]
+                            break
+
+                    if success_response and "content" in success_response:
+                        # Get the first available content type
+                        content_type = next(iter(success_response["content"]), None)
+                        if content_type and "schema" in success_response["content"][content_type]:
+                            schema = success_response["content"][content_type]["schema"]
+                            # Clean the schema for output
+                            cleaned_schema = clean_schema_for_display(schema)
+                            # Only set output_schema if the cleaned schema is not empty
+                            if cleaned_schema and cleaned_schema != {}:
+                                # Set the cleaned schema as output schema
+                                output_schema = cleaned_schema
+
             # Create the MCP tool definition
-            tool = types.Tool(name=operation_id, description=tool_description, inputSchema=input_schema)
+            tool = types.Tool(
+                name=operation_id,
+                description=tool_description,
+                inputSchema=input_schema,
+                outputSchema=output_schema,
+            )
 
             tools.append(tool)
 

--- a/fastapi_mcp/openapi/utils.py
+++ b/fastapi_mcp/openapi/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Set, Optional
 
 
 def get_single_param_type_from_schema(param_schema: Dict[str, Any]) -> str:
@@ -16,42 +16,64 @@ def get_single_param_type_from_schema(param_schema: Dict[str, Any]) -> str:
     return param_schema.get("type", "string")
 
 
-def resolve_schema_references(schema_part: Dict[str, Any], reference_schema: Dict[str, Any]) -> Dict[str, Any]:
+def resolve_schema_references(
+    schema_part: Dict[str, Any], reference_schema: Dict[str, Any], visited_paths: Optional[Set[str]] = None
+) -> Dict[str, Any]:
     """
-    Resolve schema references in OpenAPI schemas.
+    Resolve schema references in OpenAPI schemas with circular reference detection.
 
     Args:
         schema_part: The part of the schema being processed that may contain references
         reference_schema: The complete schema used to resolve references from
+        visited_paths: Set of already visited reference paths to detect circular references
 
     Returns:
         The schema with references resolved
     """
+    if visited_paths is None:
+        visited_paths = set()
+
     # Make a copy to avoid modifying the input schema
     schema_part = schema_part.copy()
 
     # Handle $ref directly in the schema
     if "$ref" in schema_part:
         ref_path = schema_part["$ref"]
+
+        # Check for circular reference
+        if ref_path in visited_paths:
+            # Return a placeholder schema to break the cycle
+            return {"type": "object", "description": "Circular reference detected", "properties": {}}
+
         # Standard OpenAPI references are in the format "#/components/schemas/ModelName"
         if ref_path.startswith("#/components/schemas/"):
             model_name = ref_path.split("/")[-1]
             if "components" in reference_schema and "schemas" in reference_schema["components"]:
                 if model_name in reference_schema["components"]["schemas"]:
-                    # Replace with the resolved schema
+                    # Add current path to visited paths
+                    visited_paths.add(ref_path)
+
+                    # Get the referenced schema and resolve it recursively
                     ref_schema = reference_schema["components"]["schemas"][model_name].copy()
-                    # Remove the $ref key and merge with the original schema
+                    resolved_ref = resolve_schema_references(ref_schema, reference_schema, visited_paths)
+
+                    # Remove the $ref key and merge with the resolved schema
                     schema_part.pop("$ref")
-                    schema_part.update(ref_schema)
+                    schema_part.update(resolved_ref)
+
+                    # Remove from visited paths after processing
+                    visited_paths.remove(ref_path)
+                    return schema_part
 
     # Recursively resolve references in all dictionary values
     for key, value in schema_part.items():
         if isinstance(value, dict):
-            schema_part[key] = resolve_schema_references(value, reference_schema)
+            schema_part[key] = resolve_schema_references(value, reference_schema, visited_paths)
         elif isinstance(value, list):
             # Only process list items that are dictionaries since only they can contain refs
             schema_part[key] = [
-                resolve_schema_references(item, reference_schema) if isinstance(item, dict) else item for item in value
+                resolve_schema_references(item, reference_schema, visited_paths) if isinstance(item, dict) else item
+                for item in value
             ]
 
     return schema_part

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -84,6 +84,10 @@ class FastApiMCP:
                 """
             ),
         ] = ["authorization"],
+        ignore_deprecated: Annotated[
+            bool,
+            Doc("Whether to ignore deprecated operations when converting OpenAPI to MCP tools. Defaults to True."),
+        ] = True,
     ):
         # Validate operation and tag filtering options
         if include_operations is not None and exclude_operations is not None:
@@ -112,6 +116,8 @@ class FastApiMCP:
         if self._auth_config:
             self._auth_config = self._auth_config.model_validate(self._auth_config)
 
+        self._ignore_deprecated = ignore_deprecated
+
         self._http_client = http_client or httpx.AsyncClient(
             transport=httpx.ASGITransport(app=self.fastapi, raise_app_exceptions=False),
             base_url=self._base_url,
@@ -136,6 +142,7 @@ class FastApiMCP:
             openapi_schema,
             describe_all_responses=self._describe_all_responses,
             describe_full_response_schema=self._describe_full_response_schema,
+            ignore_deprecated=self._ignore_deprecated,
         )
 
         # Filter tools based on operation IDs and tags

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -330,6 +330,16 @@ class FastApiMCP:
                 """
             ),
         ] = "/mcp",
+        stateless: Annotated[
+            bool,
+            Doc(
+                """
+                Whether to force stateless transport. When True, the MCP server will ignore
+                the mcp-session-id header and treat all requests as stateless.
+                Defaults to False.
+                """
+            ),
+        ] = False,
     ) -> None:
         """
         Mount the MCP server with HTTP transport to **any** FastAPI app or APIRouter.
@@ -348,7 +358,7 @@ class FastApiMCP:
 
         assert isinstance(router, (FastAPI, APIRouter)), f"Invalid router type: {type(router)}"
 
-        http_transport = FastApiHttpSessionManager(mcp_server=self.server)
+        http_transport = FastApiHttpSessionManager(mcp_server=self.server, stateless=stateless)
         dependencies = self._auth_config.dependencies if self._auth_config else None
 
         self._register_mcp_endpoints_http(router, http_transport, mount_path, dependencies)

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -46,6 +46,10 @@ class FastApiMCP:
             bool,
             Doc("Whether to include full json schema for responses in tool descriptions"),
         ] = False,
+        include_response_info: Annotated[
+            bool,
+            Doc("Whether to include response information in tool descriptions"),
+        ] = True,
         http_client: Annotated[
             Optional[httpx.AsyncClient],
             Doc(
@@ -103,6 +107,7 @@ class FastApiMCP:
         self._base_url = "http://apiserver"
         self._describe_all_responses = describe_all_responses
         self._describe_full_response_schema = describe_full_response_schema
+        self._include_response_info = include_response_info
         self._include_operations = include_operations
         self._exclude_operations = exclude_operations
         self._include_tags = include_tags
@@ -136,6 +141,7 @@ class FastApiMCP:
             openapi_schema,
             describe_all_responses=self._describe_all_responses,
             describe_full_response_schema=self._describe_full_response_schema,
+            include_response_info=self._include_response_info,
         )
 
         # Filter tools based on operation IDs and tags

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -84,6 +84,10 @@ class FastApiMCP:
                 """
             ),
         ] = ["authorization"],
+        include_output_schema: Annotated[
+            bool,
+            Doc("Whether to include outputSchema in MCP tools. Defaults to False for backwards compatibility."),
+        ] = False,
     ):
         # Validate operation and tag filtering options
         if include_operations is not None and exclude_operations is not None:
@@ -112,6 +116,7 @@ class FastApiMCP:
         if self._auth_config:
             self._auth_config = self._auth_config.model_validate(self._auth_config)
 
+        self._include_output_schema = include_output_schema
         self._http_client = http_client or httpx.AsyncClient(
             transport=httpx.ASGITransport(app=self.fastapi, raise_app_exceptions=False),
             base_url=self._base_url,
@@ -136,6 +141,7 @@ class FastApiMCP:
             openapi_schema,
             describe_all_responses=self._describe_all_responses,
             describe_full_response_schema=self._describe_full_response_schema,
+            include_output_schema=self._include_output_schema,
         )
 
         # Filter tools based on operation IDs and tags

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -75,6 +75,12 @@ class FastApiMCP:
             Optional[AuthConfig],
             Doc("Configuration for MCP authentication"),
         ] = None,
+        prefer_structured_content: Annotated[
+            bool,
+            Doc(
+                "Whether to prefer structured content over text content in responses. Defaults to False for backwards compatibility."
+            ),
+        ] = False,
         headers: Annotated[
             List[str],
             Doc(
@@ -108,6 +114,7 @@ class FastApiMCP:
         self._include_tags = include_tags
         self._exclude_tags = exclude_tags
         self._auth_config = auth_config
+        self._prefer_structured_content = prefer_structured_content
 
         if self._auth_config:
             self._auth_config = self._auth_config.model_validate(self._auth_config)
@@ -150,7 +157,7 @@ class FastApiMCP:
         @mcp_server.call_tool()
         async def handle_call_tool(
             name: str, arguments: Dict[str, Any]
-        ) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
+        ) -> Union[List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]], Dict[str, Any]]:
             # Extract HTTP request info from MCP context
             http_request_info = None
             try:
@@ -491,7 +498,7 @@ class FastApiMCP:
             Optional[HTTPRequestInfo],
             Doc("HTTP request info to forward to the actual API call"),
         ] = None,
-    ) -> List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]]:
+    ) -> Union[List[Union[types.TextContent, types.ImageContent, types.EmbeddedResource]], Dict[str, Any]]:
         """
         Execute an MCP tool by making an HTTP request to the corresponding API endpoint.
 
@@ -544,6 +551,7 @@ class FastApiMCP:
             response = await self._request(client, method, path, query, headers, body)
 
             # TODO: Better typing for the AsyncClientProtocol. It should return a ResponseProtocol that has a json() method that returns a dict/list/etc.
+            result = None
             try:
                 result = response.json()
                 result_text = json.dumps(result, indent=2, ensure_ascii=False)
@@ -559,6 +567,9 @@ class FastApiMCP:
                 raise Exception(
                     f"Error calling {tool_name}. Status code: {response.status_code}. Response: {response.text}"
                 )
+
+            if result is not None and self._prefer_structured_content:
+                return result
 
             try:
                 return [types.TextContent(type="text", text=result_text)]

--- a/fastapi_mcp/transport/http.py
+++ b/fastapi_mcp/transport/http.py
@@ -20,11 +20,13 @@ class FastApiHttpSessionManager:
         event_store: EventStore | None = None,
         json_response: bool = True,  # Default to JSON for HTTP transport
         security_settings: TransportSecuritySettings | None = None,
+        stateless: bool = False,
     ):
         self.mcp_server = mcp_server
         self.event_store = event_store
         self.json_response = json_response
         self.security_settings = security_settings
+        self.stateless = stateless
         self._session_manager: StreamableHTTPSessionManager | None = None
         self._manager_task: asyncio.Task | None = None
         self._manager_started = False
@@ -47,13 +49,12 @@ class FastApiHttpSessionManager:
             logger.debug("Starting StreamableHTTP session manager")
 
             # Create the session manager
-            # Note: We don't use stateless=True because we want to support sessions
-            # but sessions are optional as per the MCP spec
+            # Use stateless flag to determine whether to support sessions
             self._session_manager = StreamableHTTPSessionManager(
                 app=self.mcp_server,
                 event_store=self.event_store,
                 json_response=self.json_response,
-                stateless=False,  # Always support sessions, but they're optional
+                stateless=self.stateless,  # Use the stateless flag
                 security_settings=self.security_settings,
             )
 

--- a/tests/test_circular_reference.py
+++ b/tests/test_circular_reference.py
@@ -1,0 +1,201 @@
+"""
+Test cases for circular reference handling in OpenAPI schema resolution.
+"""
+
+import pytest
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List, Optional
+from fastapi.openapi.utils import get_openapi
+
+from fastapi_mcp.openapi.convert import convert_openapi_to_mcp_tools
+from fastapi_mcp.openapi.utils import resolve_schema_references
+
+
+class User(BaseModel):
+    """User model with circular reference to Post."""
+
+    id: int
+    name: str
+    posts: List["Post"] = []
+
+
+class Post(BaseModel):
+    """Post model with circular reference to User."""
+
+    id: int
+    title: str
+    author: "User"
+    comments: List["Comment"] = []
+
+
+class Comment(BaseModel):
+    """Comment model with circular reference to Post."""
+
+    id: int
+    content: str
+    post: "Post"
+
+
+class TreeNode(BaseModel):
+    """Tree node with self-reference."""
+
+    id: int
+    value: str
+    children: List["TreeNode"] = []
+    parent: Optional["TreeNode"] = None
+
+
+def create_circular_reference_app() -> FastAPI:
+    """Create a FastAPI app with circular reference models."""
+    app = FastAPI(title="Circular Reference Test", version="1.0.0")
+
+    @app.get("/users/{user_id}", operation_id="get_user")
+    async def get_user(user_id: int) -> User:
+        """Get a user by ID."""
+        return User(id=user_id, name="Test User", posts=[])
+
+    @app.get("/posts/{post_id}", operation_id="get_post")
+    async def get_post(post_id: int) -> Post:
+        """Get a post by ID."""
+        return Post(id=post_id, title="Test Post", author=User(id=1, name="Author"))
+
+    @app.get("/comments/{comment_id}", operation_id="get_comment")
+    async def get_comment(comment_id: int) -> Comment:
+        """Get a comment by ID."""
+        return Comment(id=comment_id, content="Test Comment", post=Post(id=1, title="Post"))
+
+    @app.get("/tree/{node_id}", operation_id="get_tree_node")
+    async def get_tree_node(node_id: int) -> TreeNode:
+        """Get a tree node by ID."""
+        return TreeNode(id=node_id, value="Test Node", children=[])
+
+    return app
+
+
+def test_circular_reference_schema_resolution():
+    """Test that circular references are handled gracefully."""
+    app = create_circular_reference_app()
+
+    # Generate OpenAPI schema
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # Test that resolve_schema_references doesn't raise RecursionError
+    try:
+        resolved_schema = resolve_schema_references(openapi_schema, openapi_schema)
+        assert resolved_schema is not None
+        # Should not raise RecursionError
+    except RecursionError as e:
+        pytest.fail(f"RecursionError occurred: {e}")
+
+
+def test_circular_reference_mcp_conversion():
+    """Test that MCP conversion works with circular references."""
+    app = create_circular_reference_app()
+
+    # Generate OpenAPI schema
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # Test that convert_openapi_to_mcp_tools doesn't raise RecursionError
+    try:
+        tools, operation_map = convert_openapi_to_mcp_tools(openapi_schema)
+
+        # Should successfully convert without errors
+        assert len(tools) == 4  # get_user, get_post, get_comment, get_tree_node
+        assert len(operation_map) == 4
+
+        # Check that tools are created properly
+        for tool in tools:
+            assert tool.name in ["get_user", "get_post", "get_comment", "get_tree_node"]
+            assert tool.description is not None
+            assert tool.inputSchema is not None
+
+    except RecursionError as e:
+        pytest.fail(f"RecursionError occurred during MCP conversion: {e}")
+
+
+def test_self_reference_schema():
+    """Test schema with self-reference (TreeNode)."""
+    app = create_circular_reference_app()
+
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # Test that self-referencing schemas are handled
+    try:
+        resolved_schema = resolve_schema_references(openapi_schema, openapi_schema)
+
+        # Check that TreeNode schema is properly resolved
+        tree_node_schema = resolved_schema["components"]["schemas"]["TreeNode"]
+        assert "properties" in tree_node_schema
+        assert "children" in tree_node_schema["properties"]
+
+    except RecursionError as e:
+        pytest.fail(f"RecursionError occurred with self-reference: {e}")
+
+
+def test_complex_circular_reference():
+    """Test complex circular reference chain: User -> Post -> Comment -> Post."""
+    app = create_circular_reference_app()
+
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    # Test that complex circular references are handled
+    try:
+        resolved_schema = resolve_schema_references(openapi_schema, openapi_schema)
+
+        # Check that all schemas are resolved
+        assert "components" in resolved_schema
+        assert "schemas" in resolved_schema["components"]
+
+        schemas = resolved_schema["components"]["schemas"]
+        assert "User" in schemas
+        assert "Post" in schemas
+        assert "Comment" in schemas
+        assert "TreeNode" in schemas
+
+    except RecursionError as e:
+        pytest.fail(f"RecursionError occurred with complex circular reference: {e}")
+
+
+def test_circular_reference_with_visited_paths():
+    """Test that visited paths tracking works correctly."""
+    # Create a simple schema with circular reference
+    schema_with_circular_ref = {
+        "components": {
+            "schemas": {
+                "ModelA": {"type": "object", "properties": {"b": {"$ref": "#/components/schemas/ModelB"}}},
+                "ModelB": {"type": "object", "properties": {"a": {"$ref": "#/components/schemas/ModelA"}}},
+            }
+        }
+    }
+
+    # Test that circular reference is detected and handled
+    try:
+        resolved = resolve_schema_references(schema_with_circular_ref, schema_with_circular_ref)
+        assert resolved is not None
+    except RecursionError as e:
+        pytest.fail(f"RecursionError occurred with visited paths tracking: {e}")

--- a/tests/test_openapi_conversion.py
+++ b/tests/test_openapi_conversion.py
@@ -422,3 +422,104 @@ def test_body_params_edge_cases(complex_fastapi_app: FastAPI):
     if "items" in properties:
         item_props = properties["items"]["items"]["properties"]
         assert "total" in item_props
+
+
+def test_output_schema_extraction(simple_fastapi_app: FastAPI):
+    """Test that outputSchema is correctly extracted from response schemas."""
+    openapi_schema = get_openapi(
+        title=simple_fastapi_app.title,
+        version=simple_fastapi_app.version,
+        openapi_version=simple_fastapi_app.openapi_version,
+        description=simple_fastapi_app.description,
+        routes=simple_fastapi_app.routes,
+    )
+
+    tools, operation_map = convert_openapi_to_mcp_tools(openapi_schema, include_output_schema=True)
+
+    # Check that all tools have outputSchema field (may be None)
+    for tool in tools:
+        assert hasattr(tool, "outputSchema")
+
+        # Tools with response models should have outputSchema
+        if tool.name in ["list_items", "get_item", "create_item", "update_item"]:
+            assert tool.outputSchema is not None
+            assert isinstance(tool.outputSchema, dict)
+
+            # Verify the schema structure
+            if tool.name == "list_items":
+                # Should be an array schema
+                assert tool.outputSchema.get("type") == "array"
+                assert "items" in tool.outputSchema
+            elif tool.name in ["get_item", "create_item", "update_item"]:
+                # Should be an object schema
+                assert tool.outputSchema.get("type") == "object"
+                assert "properties" in tool.outputSchema
+
+        # Tools without response models should have None outputSchema
+        elif tool.name in ["delete_item", "raise_error"]:
+            assert tool.outputSchema is None
+
+
+def test_output_schema_with_complex_responses(complex_fastapi_app: FastAPI):
+    """Test outputSchema extraction with complex response schemas."""
+    openapi_schema = get_openapi(
+        title=complex_fastapi_app.title,
+        version=complex_fastapi_app.version,
+        openapi_version=complex_fastapi_app.openapi_version,
+        description=complex_fastapi_app.description,
+        routes=complex_fastapi_app.routes,
+    )
+
+    tools, operation_map = convert_openapi_to_mcp_tools(openapi_schema, include_output_schema=True)
+
+    # Check that complex app tools have proper outputSchema
+    for tool in tools:
+        assert hasattr(tool, "outputSchema")
+
+        if tool.name in ["list_products", "get_product", "create_order", "get_customer"]:
+            assert tool.outputSchema is not None
+            assert isinstance(tool.outputSchema, dict)
+
+            # Verify schema structure based on expected response types
+            if tool.name == "list_products":
+                # PaginatedResponse is an object with an items array
+                assert tool.outputSchema.get("type") == "object"
+                assert "properties" in tool.outputSchema
+                # Check that it has an items property that is an array
+                items_prop = tool.outputSchema["properties"].get("items")
+                assert items_prop is not None
+                assert items_prop.get("type") == "array"
+            elif tool.name in ["get_product", "create_order"]:
+                # These should have properties after cleaning
+                assert "properties" in tool.outputSchema
+            elif tool.name == "get_customer":
+                # get_customer might have minimal schema after cleaning
+                assert "title" in tool.outputSchema
+
+
+def test_include_output_schema_parameter(simple_fastapi_app: FastAPI):
+    """Test that include_output_schema parameter controls outputSchema inclusion."""
+    openapi_schema = get_openapi(
+        title=simple_fastapi_app.title,
+        version=simple_fastapi_app.version,
+        openapi_version=simple_fastapi_app.openapi_version,
+        description=simple_fastapi_app.description,
+        routes=simple_fastapi_app.routes,
+    )
+
+    # Test with include_output_schema=True (default)
+    tools_with_schema, _ = convert_openapi_to_mcp_tools(openapi_schema, include_output_schema=True)
+
+    # Test with include_output_schema=False
+    tools_without_schema, _ = convert_openapi_to_mcp_tools(openapi_schema, include_output_schema=False)
+
+    # Tools with response models should have outputSchema when include_output_schema=True
+    for tool in tools_with_schema:
+        if tool.name in ["list_items", "get_item", "create_item", "update_item"]:
+            assert tool.outputSchema is not None
+        elif tool.name in ["delete_item", "raise_error"]:
+            assert tool.outputSchema is None
+
+    # All tools should have None outputSchema when include_output_schema=False
+    for tool in tools_without_schema:
+        assert tool.outputSchema is None

--- a/tests/test_stateless_http_transport.py
+++ b/tests/test_stateless_http_transport.py
@@ -1,0 +1,370 @@
+import multiprocessing
+import socket
+import time
+import os
+import signal
+import atexit
+import sys
+import threading
+import coverage
+from typing import AsyncGenerator, Generator
+from fastapi import FastAPI
+import pytest
+import httpx
+import uvicorn
+from fastapi_mcp import FastApiMCP
+import mcp.types as types
+
+
+HOST = "127.0.0.1"
+SERVER_NAME = "Test Stateless MCP Server"
+
+
+def run_server(server_port: int, fastapi_app: FastAPI, stateless: bool = False) -> None:
+    # Initialize coverage for subprocesses
+    cov = None
+    if "COVERAGE_PROCESS_START" in os.environ:
+        cov = coverage.Coverage(source=["fastapi_mcp"])
+        cov.start()
+
+        # Create a function to save coverage data at exit
+        def cleanup():
+            if cov:
+                cov.stop()
+                cov.save()
+
+        # Register multiple cleanup mechanisms to ensure coverage data is saved
+        atexit.register(cleanup)
+
+        # Setup signal handler for clean termination
+        def handle_signal(signum, frame):
+            cleanup()
+            sys.exit(0)
+
+        signal.signal(signal.SIGTERM, handle_signal)
+
+        # Backup thread to ensure coverage is written if process is terminated abruptly
+        def periodic_save():
+            while True:
+                time.sleep(1.0)
+                if cov:
+                    cov.save()
+
+        save_thread = threading.Thread(target=periodic_save)
+        save_thread.daemon = True
+        save_thread.start()
+
+    # Configure the server
+    mcp = FastApiMCP(
+        fastapi_app,
+        name=SERVER_NAME,
+        description="Test description",
+    )
+    mcp.mount_http(stateless=stateless)
+
+    # Start the server
+    server = uvicorn.Server(config=uvicorn.Config(app=fastapi_app, host=HOST, port=server_port, log_level="error"))
+    server.run()
+
+    # Give server time to start
+    while not server.started:
+        time.sleep(0.5)
+
+    # Ensure coverage is saved if exiting the normal way
+    if cov:
+        cov.stop()
+        cov.save()
+
+
+@pytest.fixture(params=[False, True])
+def stateless_mode(request: pytest.FixtureRequest) -> bool:
+    return request.param
+
+
+@pytest.fixture(params=["simple_fastapi_app"])
+def server(request: pytest.FixtureRequest, stateless_mode: bool) -> Generator[str, None, None]:
+    # Ensure COVERAGE_PROCESS_START is set in the environment for subprocesses
+    coverage_rc = os.path.abspath(".coveragerc")
+    os.environ["COVERAGE_PROCESS_START"] = coverage_rc
+
+    # Get a free port
+    with socket.socket() as s:
+        s.bind((HOST, 0))
+        server_port = s.getsockname()[1]
+
+    # Use fork method to avoid pickling issues
+    ctx = multiprocessing.get_context("fork")
+
+    # Run the server in a subprocess
+    fastapi_app = request.getfixturevalue(request.param)
+    proc = ctx.Process(
+        target=run_server,
+        kwargs={"server_port": server_port, "fastapi_app": fastapi_app, "stateless": stateless_mode},
+        daemon=True,
+    )
+    proc.start()
+
+    # Wait for server to start
+    time.sleep(2)
+
+    # Return the server URL
+    yield f"http://{HOST}:{server_port}{fastapi_app.root_path}"
+
+    # Clean up
+    proc.terminate()
+    proc.join(timeout=5)
+    if proc.is_alive():
+        proc.kill()
+        proc.join()
+
+
+@pytest.fixture()
+async def http_client(server: str) -> AsyncGenerator[httpx.AsyncClient, None]:
+    async with httpx.AsyncClient(base_url=server) as client:
+        yield client
+
+
+@pytest.mark.anyio
+async def test_stateless_initialize_request(http_client: httpx.AsyncClient, server: str, stateless_mode: bool) -> None:
+    """Test that initialize request works in both stateless and stateful modes."""
+    mcp_path = "/mcp"
+
+    response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {
+                    "sampling": None,
+                    "elicitation": None,
+                    "experimental": None,
+                    "roots": None,
+                },
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 200
+
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == 1
+    assert "result" in result
+    assert result["result"]["serverInfo"]["name"] == SERVER_NAME
+
+    # Check session ID behavior
+    session_id = response.headers.get("mcp-session-id")
+    if stateless_mode:
+        # In stateless mode, session ID should be None or empty
+        assert session_id is None or session_id == ""
+    else:
+        # In stateful mode, session ID should be present
+        assert session_id is not None
+
+
+@pytest.mark.anyio
+async def test_stateless_list_tools(http_client: httpx.AsyncClient, server: str, stateless_mode: bool) -> None:
+    """Test tool listing in both stateless and stateful modes."""
+    mcp_path = "/mcp"
+
+    # Initialize the connection
+    init_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+    assert init_response.status_code == 200
+
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+
+    # Send initialized notification
+    initialized_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            **({"mcp-session-id": session_id} if not stateless_mode else {}),
+        },
+    )
+    assert initialized_response.status_code == 202
+
+    # List tools
+    response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 2,
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            **({"mcp-session-id": session_id} if not stateless_mode else {}),
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == 2
+    assert "result" in result
+    assert "tools" in result["result"]
+    assert len(result["result"]["tools"]) > 0
+
+    # Verify we have the expected tools from the simple FastAPI app
+    tool_names = [tool["name"] for tool in result["result"]["tools"]]
+    assert "get_item" in tool_names
+    assert "list_items" in tool_names
+
+
+@pytest.mark.anyio
+async def test_stateless_call_tool(http_client: httpx.AsyncClient, server: str, stateless_mode: bool) -> None:
+    """Test tool calling in both stateless and stateful modes."""
+    mcp_path = "/mcp"
+
+    # Initialize the connection
+    init_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+    assert init_response.status_code == 200
+
+    # Extract session ID from the initialize response
+    session_id = init_response.headers.get("mcp-session-id")
+
+    # Send initialized notification
+    initialized_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            **({"mcp-session-id": session_id} if not stateless_mode else {}),
+        },
+    )
+    assert initialized_response.status_code == 202
+
+    # Call a tool
+    response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 3,
+            "params": {
+                "name": "get_item",
+                "arguments": {"item_id": 1},
+            },
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            **({"mcp-session-id": session_id} if not stateless_mode else {}),
+        },
+    )
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == 3
+    assert "result" in result
+    assert "content" in result["result"]
+
+
+@pytest.mark.anyio
+async def test_stateless_ignores_session_header(
+    http_client: httpx.AsyncClient, server: str, stateless_mode: bool
+) -> None:
+    """Test that stateless mode ignores mcp-session-id header even when provided."""
+    mcp_path = "/mcp"
+
+    if not stateless_mode:
+        pytest.skip("Skipping test for stateful mode")
+
+    # Initialize the connection
+    init_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": types.LATEST_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "1.0.0"},
+            },
+        },
+        headers={"Accept": "application/json, text/event-stream", "Content-Type": "application/json"},
+    )
+    assert init_response.status_code == 200
+
+    # Send initialized notification with a fake session ID
+    fake_session_id = "fake-session-id-12345"
+    initialized_response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": fake_session_id,  # Use fake session ID
+        },
+    )
+    assert initialized_response.status_code == 202
+
+    # List tools with fake session ID
+    response = await http_client.post(
+        mcp_path,
+        json={
+            "jsonrpc": "2.0",
+            "method": "tools/list",
+            "id": 2,
+        },
+        headers={
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+            "mcp-session-id": fake_session_id,  # Use fake session ID
+        },
+    )
+
+    # Should work regardless of the session ID in stateless mode
+    assert response.status_code == 200
+    result = response.json()
+    assert result["jsonrpc"] == "2.0"
+    assert result["id"] == 2
+    assert "result" in result
+    assert "tools" in result["result"]


### PR DESCRIPTION
## Problem
Fixes #238 - RecursionError when processing recursive Pydantic models with circular references.

## Solution
- Add `visited_paths` tracking to detect circular references
- Return placeholder schema when circular reference detected
- Maintain backward compatibility

## How it works
When a circular reference is detected:
1. **First occurrence**: Normal schema resolution with all properties
2. **Subsequent occurrences**: Placeholder schema with `{"type": "object", "description": "Circular reference detected", "properties": {}}`

## Impact & Limitations
✅ **Preserved functionality**:
- All non-circular properties remain fully accessible
- First-level schema information is complete
- API documentation remains clear and usable

⚠️ **Limitations**:
- Deep nested structures beyond the circular reference point show placeholder
- Infinite depth nesting is not supported (by design)

## Changes
- Modified `resolve_schema_references()` in `fastapi_mcp/openapi/utils.py`
- Added comprehensive test suite for circular reference scenarios
- All existing tests pass

## Testing
- ✅ Circular reference detection works correctly
- ✅ MCP conversion handles recursive models gracefully  
- ✅ No regression in existing functionality
- ✅ Schema completeness verified for practical use cases