### PR TITLE
fix: description incorrectly passed as version to MCP server

### DIFF
--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -34,6 +34,10 @@ class FastApiMCP:
             Optional[str],
             Doc("Name for the MCP server (defaults to app.title)"),
         ] = None,
+        version: Annotated[
+            Optional[str],
+            Doc("Version for the MCP server (defaults to app.version)"),
+        ] = None,
         description: Annotated[
             Optional[str],
             Doc("Description for the MCP server (defaults to app.description)"),
@@ -98,6 +102,7 @@ class FastApiMCP:
 
         self.fastapi = fastapi
         self.name = name or self.fastapi.title or "FastAPI MCP"
+        self.version = version or self.fastapi.version
         self.description = description or self.fastapi.description
 
         self._base_url = "http://apiserver"
@@ -141,7 +146,7 @@ class FastApiMCP:
         # Filter tools based on operation IDs and tags
         self.tools = self._filter_tools(all_tools, openapi_schema)
 
-        mcp_server: Server = Server(self.name, self.description)
+        mcp_server: Server = Server(name=self.name, version=self.version, instructions=self.description)
 
         @mcp_server.list_tools()
         async def handle_list_tools() -> List[types.Tool]:
@@ -654,3 +659,4 @@ class FastApiMCP:
             }
 
         return filtered_tools
+

--- a/tests/test_basic_functionality.py
+++ b/tests/test_basic_functionality.py
@@ -9,11 +9,13 @@ def test_create_mcp_server(simple_fastapi_app: FastAPI):
     mcp = FastApiMCP(
         simple_fastapi_app,
         name="Test MCP Server",
+        version="1.2.3",
         description="Test description",
     )
 
     # Verify the MCP server was created correctly
     assert mcp.name == "Test MCP Server"
+    assert mcp.version == "1.2.3"
     assert mcp.description == "Test description"
     assert isinstance(mcp.server, Server)
     assert len(mcp.tools) > 0, "Should have extracted tools from the app"
@@ -31,6 +33,7 @@ def test_default_values(simple_fastapi_app: FastAPI):
 
     # Verify default values
     assert mcp.name == simple_fastapi_app.title
+    assert mcp.version == simple_fastapi_app.version
     assert mcp.description == simple_fastapi_app.description
 
     # Mount with default path


### PR DESCRIPTION
## Describe your changes

Fixed incorrect parameter passing to the MCP `Server` constructor. The `Server` constructor was being called with positional arguments, causing `description` to be passed as `version`:

```python
# Before (incorrect)
Server(self.name, self.description)

# After (correct)
Server(self.name, version=self.version, instructions=self.description)
```
Fixes #293

## Checklist before requesting a review

- [x] Added relevant tests
- [x] Run ruff & mypy
- [x] All tests pass
